### PR TITLE
feat(overlay): make floating window resizable

### DIFF
--- a/Textream/Textream/NotchOverlayController.swift
+++ b/Textream/Textream/NotchOverlayController.swift
@@ -351,7 +351,7 @@ class NotchOverlayController: NSObject {
 
         let panel = NSPanel(
             contentRect: NSRect(x: xPosition, y: yPosition, width: panelWidth, height: panelHeight),
-            styleMask: [.borderless, .nonactivatingPanel],
+            styleMask: [.borderless, .nonactivatingPanel, .resizable],
             backing: .buffered,
             defer: false
         )
@@ -362,6 +362,8 @@ class NotchOverlayController: NSObject {
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
         panel.ignoresMouseEvents = false
         panel.isMovableByWindowBackground = true
+        panel.minSize = NSSize(width: 280, height: panelHeight)
+        panel.maxSize = NSSize(width: 500, height: panelHeight + 350)
         panel.sharingType = NotchSettings.shared.hideFromScreenShare ? .none : .readOnly
         panel.contentView = contentView
 


### PR DESCRIPTION
Add resizable support to the floating window overlay so users can drag the edges to expand or shrink it.

- Add `.resizable` to floating panel style mask
- Set min size (280px wide x base height) and max size (500px wide x base height + 350px)
- Floating window remains draggable via background

If this doesnt make sense for the project Im happy to have it live in my fork and live happily ever after, no worries at all!