### PR TITLE
fix: always show page sidebar and read current page on play

### DIFF
--- a/Textream/Textream/ContentView.swift
+++ b/Textream/Textream/ContentView.swift
@@ -408,15 +408,13 @@ Happy presenting! [wave]
         Group {
             if NotchSettings.shared.directorModeEnabled {
                 directorOverlay
-            } else if service.pages.count > 1 {
+            } else {
                 NavigationSplitView {
                     pageSidebar
                 } detail: {
                     mainContent
                 }
                 .navigationSplitViewColumnWidth(min: 160, ideal: 200, max: 260)
-            } else {
-                mainContent
             }
         }
         .alert(dropAlertTitle, isPresented: Binding(get: { dropError != nil }, set: { if !$0 { dropError = nil } })) {
@@ -616,7 +614,13 @@ Happy presenting! [wave]
             NSApp.windows.first?.makeKeyAndOrderFront(nil)
         }
         service.readPages.removeAll()
-        service.currentPageIndex = 0
+        // If the current page is empty, find the first non-empty page
+        let currentText = service.currentPageText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if currentText.isEmpty {
+            if let firstNonEmpty = service.pages.firstIndex(where: { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }) {
+                service.currentPageIndex = firstNonEmpty
+            }
+        }
         service.readCurrentPage()
         isRunning = true
     }


### PR DESCRIPTION
## Summary
- **Always show the page sidebar** -- previously it only appeared when multiple pages existed, but the Add Page button lives inside the sidebar, making it impossible to add pages from a single-page state.
- **Play reads the current page** -- pressing play always reset to page 0 (the welcome text) instead of reading whichever page the user was currently editing. Now it reads the active page, falling back to the first non-empty page only if the current one is blank.

## Test plan
- [ ] Open the app fresh -- sidebar should be visible with one page and Add Page button at the bottom
- [ ] Add a second page, type text, press play -- should read the page you are viewing, not page 1
- [ ] With only the welcome text on page 1, add a new page with custom text, select it, press play -- should read your custom text

Generated with [Claude Code](https://claude.com/claude-code)