### PR TITLE
Fix: Keep text visible after WPM auto-scroll reaches the end

### DIFF
--- a/Textream/Textream/BrowserServer.swift
+++ b/Textream/Textream/BrowserServer.swift
@@ -201,7 +201,10 @@ class BrowserServer {
         }
 
         let effective = min(charCount, totalCharCount)
-        let isDone = totalCharCount > 0 && effective >= totalCharCount
+        let rawDone = totalCharCount > 0 && effective >= totalCharCount
+        // In classic/silence-paused modes on the last page, suppress Done so the
+        // browser keeps showing the prompter text (speaker may still be talking).
+        let isDone = rawDone && (mode == .wordTracking || hasNextPage)
 
         let highlightWords = mode == .wordTracking
 

--- a/Textream/Textream/BrowserServer.swift
+++ b/Textream/Textream/BrowserServer.swift
@@ -187,14 +187,18 @@ class BrowserServer {
 
         let charCount: Int
         let mode = NotchSettings.shared.listeningMode
+        // Check if scroll already reached the end, to stop advancing the timer
+        let scrollDone = totalCharCount > 0 && charOffsetForWordProgress(timerWordProgress) >= totalCharCount
         switch mode {
         case .wordTracking:
             charCount = speechRecognizer?.recognizedCharCount ?? 0
         case .classic:
-            timerWordProgress += NotchSettings.shared.scrollSpeed * 0.1
+            if !scrollDone {
+                timerWordProgress += NotchSettings.shared.scrollSpeed * 0.1
+            }
             charCount = charOffsetForWordProgress(timerWordProgress)
         case .silencePaused:
-            if speechRecognizer?.isListening == true && (speechRecognizer?.isSpeaking ?? false) {
+            if !scrollDone && speechRecognizer?.isListening == true && (speechRecognizer?.isSpeaking ?? false) {
                 timerWordProgress += NotchSettings.shared.scrollSpeed * 0.1
             }
             charCount = charOffsetForWordProgress(timerWordProgress)

--- a/Textream/Textream/ExternalDisplayController.swift
+++ b/Textream/Textream/ExternalDisplayController.swift
@@ -176,7 +176,7 @@ struct ExternalDisplayView: View {
         ZStack {
             Color.black.ignoresSafeArea()
 
-            if isDone {
+            if isDone && (listeningMode == .wordTracking || hasNextPage) {
                 doneView
             } else {
                 prompterView
@@ -192,7 +192,7 @@ struct ExternalDisplayView: View {
         .scaleEffect(x: mirrorAxis?.scaleX ?? 1, y: mirrorAxis?.scaleY ?? 1)
         .animation(.easeInOut(duration: 0.5), value: isDone)
         .onChange(of: isDone) { _, done in
-            if done {
+            if done && listeningMode == .wordTracking {
                 speechRecognizer.stop()
             }
         }

--- a/Textream/Textream/NotchOverlayController.swift
+++ b/Textream/Textream/NotchOverlayController.swift
@@ -721,7 +721,7 @@ struct NotchOverlayView: View {
 
                         if content.showPagePicker {
                             pagePickerView
-                        } else if isDone {
+                        } else if isDone && (listeningMode == .wordTracking || hasNextPage) {
                             doneView
                         } else {
                             prompterView
@@ -765,12 +765,19 @@ struct NotchOverlayView: View {
         .animation(.easeInOut(duration: 0.5), value: isDone)
         .onChange(of: isDone) { _, done in
             if done {
-                // Stop listening when page is done
-                speechRecognizer.stop()
+                // In word tracking mode, stop listening when page is done
+                if listeningMode == .wordTracking {
+                    speechRecognizer.stop()
+                }
                 if !hasNextPage {
-                    // Show "Done" briefly, then auto-dismiss
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-                        speechRecognizer.shouldDismiss = true
+                    // Only auto-dismiss in word tracking mode.
+                    // In classic/silence-paused modes the speaker may still be
+                    // talking after the auto-scroll finishes, so keep the text
+                    // visible and let them dismiss manually (X button or Esc).
+                    if listeningMode == .wordTracking {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                            speechRecognizer.shouldDismiss = true
+                        }
                     }
                 } else if NotchSettings.shared.autoNextPage {
                     startCountdown()
@@ -1213,7 +1220,7 @@ struct FloatingOverlayView: View {
         VStack(spacing: 0) {
             if content.showPagePicker {
                 floatingPagePickerView
-            } else if isDone {
+            } else if isDone && (listeningMode == .wordTracking || hasNextPage) {
                 floatingDoneView
             } else {
                 floatingPrompterView
@@ -1260,11 +1267,14 @@ struct FloatingOverlayView: View {
         .animation(.easeInOut(duration: 0.5), value: isDone)
         .onChange(of: isDone) { _, done in
             if done {
-                // Stop listening when page is done
-                speechRecognizer.stop()
+                if listeningMode == .wordTracking {
+                    speechRecognizer.stop()
+                }
                 if !hasNextPage {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-                        speechRecognizer.shouldDismiss = true
+                    if listeningMode == .wordTracking {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                            speechRecognizer.shouldDismiss = true
+                        }
                     }
                 } else if followingCursor || NotchSettings.shared.autoNextPage {
                     startCountdown()


### PR DESCRIPTION
## Summary

Fixes #29

In Classic and Voice-Activated (silence-paused) modes, the overlay would immediately switch to a "Done!" screen and auto-dismiss 1 second after the auto-scroll reached the last word. This made timed mode unusable because speakers typically finish talking 10–20 seconds after the scroll ends.

Now in timer-based modes (Classic/Voice-Activated), when the scroll reaches the end on the last page:
- The prompter text stays visible instead of switching to "Done!"
- The overlay does not auto-dismiss
- The speaker can close manually via the X button or Esc key

Word Tracking mode behavior is unchanged (auto-dismiss is appropriate there since it knows when the speaker actually finishes).

## Changes

- **NotchOverlayController.swift** — Gate `doneView` and auto-dismiss on `listeningMode == .wordTracking` in both `NotchOverlayView` and `FloatingOverlayView`
- **ExternalDisplayController.swift** — Same fix for `ExternalDisplayView` (fullscreen and external display)
- **BrowserServer.swift** — Suppress `isDone` in the WebSocket state for classic/silencePaused on the last page; also stop `timerWordProgress` from advancing after scroll completes

## Test plan

- [ ] Classic mode, single page: auto-scroll reaches end → text stays visible, dismiss manually with X or Esc
- [ ] Classic mode, multi-page: auto-scroll reaches end → "Next Page" button appears as before
- [ ] Voice-Activated mode, single page: same as Classic
- [ ] Word Tracking mode: behavior unchanged — auto-dismiss after 1s on last page
- [ ] Fullscreen mode: text stays visible in Classic/Voice-Activated
- [ ] Browser source (if enabled): prompter text stays visible in Classic/Voice-Activated