### PR TITLE
fix: downmix multi-channel audio to mono for SFSpeechRecognizer

### DIFF
--- a/Textream/Textream/SpeechRecognizer.swift
+++ b/Textream/Textream/SpeechRecognizer.swift
@@ -287,10 +287,10 @@ class SpeechRecognizer {
         recognitionRequest.shouldReportPartialResults = true
 
         let inputNode = audioEngine.inputNode
-        let recordingFormat = inputNode.outputFormat(forBus: 0)
+        let hardwareFormat = inputNode.outputFormat(forBus: 0)
 
         // Guard against invalid format during device transitions (e.g. mic switch)
-        guard recordingFormat.sampleRate > 0, recordingFormat.channelCount > 0 else {
+        guard hardwareFormat.sampleRate > 0, hardwareFormat.channelCount > 0 else {
             // Retry after a longer delay to let the audio system settle
             if retryCount < maxRetries {
                 retryCount += 1
@@ -301,6 +301,17 @@ class SpeechRecognizer {
             }
             return
         }
+
+        // SFSpeechRecognizer requires mono audio. Multi-channel devices (e.g.
+        // RODECaster Pro II at 2ch/48kHz) cause the recognition task to silently
+        // return no results. Request a mono tap and let AVAudioEngine downmix.
+        let monoFormat = AVAudioFormat(
+            commonFormat: hardwareFormat.commonFormat,
+            sampleRate: hardwareFormat.sampleRate,
+            channels: 1,
+            interleaved: hardwareFormat.isInterleaved
+        )
+        let tapFormat = (hardwareFormat.channelCount > 1) ? monoFormat : hardwareFormat
 
         // Observe audio configuration changes (e.g. mic switched externally) to restart gracefully
         configurationChangeObserver = NotificationCenter.default.addObserver(
@@ -315,7 +326,7 @@ class SpeechRecognizer {
         // Belt-and-suspenders: ensure no stale tap exists before installing
         inputNode.removeTap(onBus: 0)
 
-        inputNode.installTap(onBus: 0, bufferSize: 1024, format: nil) { [weak self] buffer, _ in
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: tapFormat) { [weak self] buffer, _ in
             recognitionRequest.append(buffer)
 
             guard let channelData = buffer.floatChannelData?[0] else { return }


### PR DESCRIPTION
## Summary

- **Problem:** `SFSpeechRecognizer` silently returns no results when receiving multi-channel audio buffers. USB audio interfaces like the RODECaster Pro II send 2-channel 48kHz audio, and the previous `format: nil` tap delivered these buffers unchanged to the recognition request. The waveform visualization works fine (it only reads channel 0), but the recognizer never fires its result callback.

- **Fix:** When the input device has more than one channel, create a mono `AVAudioFormat` at the hardware sample rate and pass it to `installTap`. `AVAudioEngine` handles the downmix automatically. Single-channel devices (e.g. built-in mic) are unaffected.

## Test plan

- [ ] Test with a multi-channel USB audio interface (e.g. RODECaster Pro II, Focusrite Scarlett, etc.) — speech recognition should now produce results
- [ ] Test with built-in microphone — no change in behavior
- [ ] Test switching between built-in mic and USB interface mid-session — recognition should restart and work with either device

🤖 Generated with [Claude Code](https://claude.com/claude-code)