### PR TITLE
fix: start playback from selected page and install key monitor in pin…

### DIFF
--- a/Textream/Textream/ContentView.swift
+++ b/Textream/Textream/ContentView.swift
@@ -532,10 +532,8 @@ Happy presenting! [wave]
             get: { service.currentPageIndex },
             set: { newValue in
                 if let index = newValue {
-                    DispatchQueue.main.async {
-                        withAnimation(.easeInOut(duration: 0.15)) {
-                            service.currentPageIndex = index
-                        }
+                    withAnimation(.easeInOut(duration: 0.15)) {
+                        service.currentPageIndex = index
                     }
                 }
             }

--- a/Textream/Textream/NotchOverlayController.swift
+++ b/Textream/Textream/NotchOverlayController.swift
@@ -263,6 +263,8 @@ class NotchOverlayController: NSObject {
         if settings.notchDisplayMode == .followMouse {
             startMouseTracking()
         }
+
+        installKeyMonitor()
     }
 
     private func showFollowCursor(settings: NotchSettings, screen: NSScreen) {


### PR DESCRIPTION
…ned mode

Two bugs fixed:

1. Clicking a page in the sidebar then pressing Play always started from page 1 instead of the selected page. Root cause: the `sidebarSelection` setter wrapped the `currentPageIndex` update in `DispatchQueue.main.async`, deferring it asynchronously. Since SwiftUI binding setters are already called on the main thread, this wrapper was unnecessary and caused `run()` to read the stale value (0) before the update applied. Fix: remove the async dispatch so `currentPageIndex` is updated synchronously on selection.

2. `showPinned()` was the only display mode not calling `installKeyMonitor()`, so the ESC key did not work to dismiss the overlay in pinned mode.