### PR TITLE
Fix Chinese IME marked text handling

### DIFF
--- a/Textream/Textream/HighlightingTextEditor.swift
+++ b/Textream/Textream/HighlightingTextEditor.swift
@@ -68,6 +68,10 @@ struct HighlightingTextEditor: NSViewRepresentable {
     func updateNSView(_ scrollView: NSScrollView, context: Context) {
         guard let textView = scrollView.documentView as? NSTextView else { return }
 
+        if textView.hasMarkedText() {
+            return
+        }
+
         if textView.string != text {
             let selectedRanges = textView.selectedRanges
             textView.string = text
@@ -106,12 +110,14 @@ struct HighlightingTextEditor: NSViewRepresentable {
 
         func textDidChange(_ notification: Notification) {
             guard let textView = notification.object as? NSTextView else { return }
+            guard !textView.hasMarkedText() else { return }
             parent.text = textView.string
             applyHighlighting(textView)
         }
 
         func textViewDidChangeSelection(_ notification: Notification) {
             guard let textView = notification.object as? NSTextView else { return }
+            guard !textView.hasMarkedText() else { return }
             let pos = textView.selectedRange().location
             if parent.editorCaretPosition != pos {
                 DispatchQueue.main.async { [weak self] in
@@ -141,6 +147,7 @@ struct HighlightingTextEditor: NSViewRepresentable {
 
         func applyHighlighting(_ textView: NSTextView) {
             guard let textStorage = textView.textStorage else { return }
+            guard !textView.hasMarkedText() else { return }
             let fullRange = NSRange(location: 0, length: textStorage.length)
             let text = textStorage.string
 


### PR DESCRIPTION
## Summary
- skip SwiftUI/AppKit text synchronization while the editor has marked text from an input method
- avoid reapplying highlighting or restoring selection during IME composition
- allow Chinese IME pre-edit text and candidate selection to complete before updating the bound script text

Fixes #34.

## Validation
- Manually verified on macOS with Sogou Pinyin: typed `nihao` and committed it as `你好` in the Textream editor
- Manually verified composition stays visible before committing `ceshi` to `测试`
- `git diff --check`