### PR TITLE
Fix Voice-Activated mode not scrolling with low-gain microphones

### DIFF
--- a/Textream/Textream/SpeechRecognizer.swift
+++ b/Textream/Textream/SpeechRecognizer.swift
@@ -80,13 +80,10 @@ class SpeechRecognizer {
     var shouldDismiss: Bool = false
     var shouldAdvancePage: Bool = false
 
-    /// True when recent audio levels indicate the user is actively speaking
-    var isSpeaking: Bool {
-        let recent = audioLevels.suffix(10)
-        guard !recent.isEmpty else { return false }
-        let avg = recent.reduce(0, +) / CGFloat(recent.count)
-        return avg > 0.08
-    }
+    /// True when recent audio energy indicates the user is actively speaking.
+    /// Updated from the audio tap using an adaptive noise floor so detection
+    /// works across microphones with different gain levels.
+    var isSpeaking: Bool = false
 
     private var speechRecognizer: SFSpeechRecognizer?
     private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
@@ -106,6 +103,11 @@ class SpeechRecognizer {
     /// Sliding window of recent match positions for confidence gating.
     /// We require 2-of-3 recent results to agree before committing a forward jump.
     private var recentMatchPositions: [Int] = []
+
+    // Adaptive voice-activity detection (drives Voice-Activated / silence-paused scrolling)
+    private var noiseFloor: CGFloat = 0.02
+    private var lastSpeechAt: Date = .distantPast
+    private let speechHangover: TimeInterval = 0.25
 
     /// Update the source text while preserving the current recognized char count.
     /// Used by Director Mode to live-edit unread text without resetting read progress.
@@ -143,6 +145,9 @@ class SpeechRecognizer {
         matchStartOffset = 0
         retryCount = 0
         recentMatchPositions = []
+        noiseFloor = 0.02
+        lastSpeechAt = .distantPast
+        isSpeaking = false
         error = nil
         sessionGeneration += 1
 
@@ -371,10 +376,12 @@ class SpeechRecognizer {
             let level = CGFloat(min(rms * 5, 1.0))
 
             DispatchQueue.main.async {
-                self?.audioLevels.append(level)
-                if (self?.audioLevels.count ?? 0) > 30 {
-                    self?.audioLevels.removeFirst()
+                guard let self else { return }
+                self.audioLevels.append(level)
+                if self.audioLevels.count > 30 {
+                    self.audioLevels.removeFirst()
                 }
+                self.updateVoiceActivity(level: level)
             }
         }
 
@@ -454,6 +461,34 @@ class SpeechRecognizer {
             cleanupRecognition()
             scheduleBeginRecognition(after: 0.5)
         }
+    }
+
+    // MARK: - Voice-activity detection
+
+    /// Adaptive voice-activity detection driving Voice-Activated scrolling.
+    /// Tracks a slowly-adapting noise floor during silence and flags speech when
+    /// the level rises above it, with a short hangover so natural pauses between
+    /// words don't stall scrolling. Adapting relative to the noise floor keeps
+    /// detection reliable across microphones with very different gain levels.
+    private func updateVoiceActivity(level: CGFloat) {
+        // Continuously adapt the noise floor: rise slowly so brief speech peaks
+        // don't pull it up, but fall quickly so it settles into quiet passages.
+        // This lets steady ambient noise get absorbed into the floor (preventing
+        // false "always speaking") while keeping the floor low for quiet mics.
+        if level > noiseFloor {
+            noiseFloor += (level - noiseFloor) * 0.01
+        } else {
+            noiseFloor += (level - noiseFloor) * 0.30
+        }
+
+        // Gain-relative threshold: speech sits well above the noise floor on any
+        // mic. The absolute minimum stops near-silent rooms (floor ~0) from
+        // triggering on tiny fluctuations.
+        let threshold = max(0.025, noiseFloor * 1.8)
+        if level > threshold {
+            lastSpeechAt = Date()
+        }
+        isSpeaking = Date().timeIntervalSince(lastSpeechAt) < speechHangover
     }
 
     // MARK: - Thread-safe buffer appending


### PR DESCRIPTION
## Summary

Fixes the **Voice-Activated** listening mode (`silencePaused` — "Scrolls while you speak, pauses when you're silent"), which did not scroll at all for many users even while speaking clearly.

Fixes #49

## Root cause

Voice-Activated mode only advances the teleprompter while `SpeechRecognizer.isSpeaking` is `true`. That property used a single hard-coded **absolute** threshold over recent audio levels:

```swift
var isSpeaking: Bool {
    let recent = audioLevels.suffix(10)
    let avg = recent.reduce(0, +) / CGFloat(recent.count)
    return avg > 0.08
}
```

`0.08` is too high for common microphones (built-in MacBook mic, AirPods at a normal distance), where speech rarely averages that level. So `isSpeaking` stayed `false` and the text never scrolled. **Classic** and **Word Tracking** modes don't depend on `isSpeaking`, which is why only the third mode was affected.

## Fix

Replace the fixed threshold with adaptive voice-activity detection in `SpeechRecognizer`:

- **Adaptive noise floor** — rises slowly, falls fast. Steady ambient noise gets absorbed into the floor (prevents false "always speaking"), while the floor stays low for quiet mics.
- **Gain-relative threshold** — `max(0.025, noiseFloor * 1.8)`, so detection works across very different mic gains (quiet built-in mic through loud external mic).
- **0.25s hangover** — natural pauses between words no longer stall scrolling.
- VAD state resets on each `start(with:)`.

The notch overlay, external display, and browser teleprompters all consume `isSpeaking`, so they all benefit with no changes to their scroll logic.

## Testing

The fix is pure logic, so I validated it with a deterministic harness that runs both the old and new algorithms over simulated audio-level streams at the real audio-buffer rate (~0.02s/frame):

| Scenario | Old | New |
|---|---|---|
| Low-gain speech (~0.06) — the bug | **0% (never scrolls)** | 74% ✅ |
| Pure silence | 0% | 0% ✅ |
| Speech with word gaps | 55% (stutters) | 100% ✅ |
| Noisy mic + speech burst | 18% | detects burst, settles in ambient ✅ |
| Stop-after-silence latency | — | 0.22s ✅ |
| High-gain speech (~0.45) | 100% | 87% ✅ |

The app also builds cleanly (`xcodebuild ... build` → **BUILD SUCCEEDED**).

> Note: the harness covers the detection logic, not the live `AVAudioEngine` tap / Speech framework wiring (unchanged). A quick real-mic run of Voice-Activated mode is still recommended.
