### PR TITLE
fix: scroll anchor consistency, smooth-mode lookahead, and word-tracking freeze

### DIFF
--- a/Textream/Textream/MarqueeTextView.swift
+++ b/Textream/Textream/MarqueeTextView.swift
@@ -246,24 +246,33 @@ struct SpeechScrollView: View {
         )
     }
 
+    /// Y position in the viewport where the active word is anchored.
+    /// Smooth modes (classic/silence-paused) anchor in the lower third so read
+    /// text stays visible above while the next lines remain visible below —
+    /// anchoring at the very bottom leaves the speaker no lookahead.
+    /// wordProgressAtCurrentOffset must use the same anchor, otherwise
+    /// releasing a manual scroll snaps the text by the difference.
+    private func readingAnchorY(containerHeight: CGFloat) -> CGFloat {
+        smoothScroll ? containerHeight * 0.7 : containerHeight * 0.5
+    }
+
     private func recalcCenter(containerHeight: CGFloat) {
-        let center = containerHeight * 0.5
+        let anchor = readingAnchorY(containerHeight: containerHeight)
 
         if smoothScroll {
-            // Classic/silence-paused: anchor active word near the bottom, scrolling up
-            let bottomAnchor = containerHeight - 20
+            // Classic/silence-paused: continuous word progress, interpolated
             let wordIdx = Int(smoothWordProgress)
             let fraction = smoothWordProgress - Double(wordIdx)
             let clampedIdx = max(0, min(wordIdx, words.count - 1))
             guard let wordY = wordYPositions[clampedIdx] else { return }
             let nextY = wordYPositions[clampedIdx + 1] ?? wordY
             let interpolatedY = wordY + (nextY - wordY) * CGFloat(fraction)
-            scrollOffset = bottomAnchor - interpolatedY
+            scrollOffset = anchor - interpolatedY
         } else {
-            // Word-tracking/voice-activated: active word at vertical center
+            // Word tracking: active word at vertical center
             let wordIdx = activeWordIndex()
             if let wordY = wordYPositions[wordIdx] {
-                let target = center - wordY
+                let target = anchor - wordY
                 // Only update if it actually changed to avoid redundant animations
                 if abs(scrollOffset - target) > 1 {
                     scrollOffset = target
@@ -274,9 +283,9 @@ struct SpeechScrollView: View {
 
     /// Find the word progress at the current visual position (scrollOffset + manualOffset)
     private func wordProgressAtCurrentOffset() -> Double {
-        let center = containerHeight * 0.5
-        // The Y position currently at the center of the view
-        let targetY = center - (scrollOffset + manualOffset)
+        let anchor = readingAnchorY(containerHeight: containerHeight)
+        // The Y position currently at the reading anchor line
+        let targetY = anchor - (scrollOffset + manualOffset)
 
         // Find the closest word and interpolate
         let sorted = wordYPositions.sorted { $0.key < $1.key }

--- a/Textream/Textream/SpeechRecognizer.swift
+++ b/Textream/Textream/SpeechRecognizer.swift
@@ -601,16 +601,20 @@ class SpeechRecognizer {
         // Strategy 2: word-level match (handles STT word substitutions)
         let wordResult = wordLevelMatch(spoken: spoken)
 
-        // Use agreement-based selection instead of blind max().
         // If both strategies agree within a tolerance, use the average.
-        // If they disagree wildly, use the more conservative (lower) result
-        // to avoid false-positive jumps.
+        // If they disagree wildly, trust the word-level matcher: the char
+        // matcher's 3-char resync cannot bridge word-level substitutions
+        // ("sits" transcribed as "says"), after which it wedges permanently
+        // and taking min() would veto the word matcher forever, freezing the
+        // highlight. Word-level movement requires consecutive fuzzy word
+        // matches, and the 2-of-3 agreement gate below still filters
+        // transient false jumps.
         let best: Int
         let tolerance = 20 // characters
         if abs(charResult - wordResult) <= tolerance {
             best = (charResult + wordResult) / 2
         } else {
-            best = min(charResult, wordResult)
+            best = wordResult
         }
 
         let newCount = matchStartOffset + best

--- a/Textream/Textream/SpeechRecognizer.swift
+++ b/Textream/Textream/SpeechRecognizer.swift
@@ -80,26 +80,12 @@ class SpeechRecognizer {
     var shouldDismiss: Bool = false
     var shouldAdvancePage: Bool = false
 
-    /// True when recent audio levels indicate the user is actively speaking.
-    /// Uses hysteresis: a level hovering around a single threshold would
-    /// rapidly toggle this flag and stutter the silence-paused scroll timer.
-    private(set) var isSpeaking: Bool = false
-
-    private static let speakingOnLevel: CGFloat = 0.08
-    private static let speakingOffLevel: CGFloat = 0.05
-
-    private func updateSpeakingState() {
+    /// True when recent audio levels indicate the user is actively speaking
+    var isSpeaking: Bool {
         let recent = audioLevels.suffix(10)
-        guard !recent.isEmpty else {
-            isSpeaking = false
-            return
-        }
+        guard !recent.isEmpty else { return false }
         let avg = recent.reduce(0, +) / CGFloat(recent.count)
-        if isSpeaking {
-            if avg < Self.speakingOffLevel { isSpeaking = false }
-        } else if avg > Self.speakingOnLevel {
-            isSpeaking = true
-        }
+        return avg > 0.08
     }
 
     private var speechRecognizer: SFSpeechRecognizer?
@@ -257,9 +243,6 @@ class SpeechRecognizer {
             audioEngine.stop()
         }
         audioEngine.inputNode.removeTap(onBus: 0)
-        // The tap no longer feeds audioLevels, so the speaking state would
-        // otherwise freeze at its last value.
-        isSpeaking = false
     }
 
     private func cleanupRecognition() {
@@ -388,12 +371,10 @@ class SpeechRecognizer {
             let level = CGFloat(min(rms * 5, 1.0))
 
             DispatchQueue.main.async {
-                guard let self else { return }
-                self.audioLevels.append(level)
-                if self.audioLevels.count > 30 {
-                    self.audioLevels.removeFirst()
+                self?.audioLevels.append(level)
+                if (self?.audioLevels.count ?? 0) > 30 {
+                    self?.audioLevels.removeFirst()
                 }
-                self.updateSpeakingState()
             }
         }
 

--- a/Textream/Textream/SpeechRecognizer.swift
+++ b/Textream/Textream/SpeechRecognizer.swift
@@ -80,12 +80,26 @@ class SpeechRecognizer {
     var shouldDismiss: Bool = false
     var shouldAdvancePage: Bool = false
 
-    /// True when recent audio levels indicate the user is actively speaking
-    var isSpeaking: Bool {
+    /// True when recent audio levels indicate the user is actively speaking.
+    /// Uses hysteresis: a level hovering around a single threshold would
+    /// rapidly toggle this flag and stutter the silence-paused scroll timer.
+    private(set) var isSpeaking: Bool = false
+
+    private static let speakingOnLevel: CGFloat = 0.08
+    private static let speakingOffLevel: CGFloat = 0.05
+
+    private func updateSpeakingState() {
         let recent = audioLevels.suffix(10)
-        guard !recent.isEmpty else { return false }
+        guard !recent.isEmpty else {
+            isSpeaking = false
+            return
+        }
         let avg = recent.reduce(0, +) / CGFloat(recent.count)
-        return avg > 0.08
+        if isSpeaking {
+            if avg < Self.speakingOffLevel { isSpeaking = false }
+        } else if avg > Self.speakingOnLevel {
+            isSpeaking = true
+        }
     }
 
     private var speechRecognizer: SFSpeechRecognizer?
@@ -243,6 +257,9 @@ class SpeechRecognizer {
             audioEngine.stop()
         }
         audioEngine.inputNode.removeTap(onBus: 0)
+        // The tap no longer feeds audioLevels, so the speaking state would
+        // otherwise freeze at its last value.
+        isSpeaking = false
     }
 
     private func cleanupRecognition() {
@@ -371,10 +388,12 @@ class SpeechRecognizer {
             let level = CGFloat(min(rms * 5, 1.0))
 
             DispatchQueue.main.async {
-                self?.audioLevels.append(level)
-                if (self?.audioLevels.count ?? 0) > 30 {
-                    self?.audioLevels.removeFirst()
+                guard let self else { return }
+                self.audioLevels.append(level)
+                if self.audioLevels.count > 30 {
+                    self.audioLevels.removeFirst()
                 }
+                self.updateSpeakingState()
             }
         }
 


### PR DESCRIPTION
## Summary

Three related fixes for auto-scroll and word tracking, found while debugging why the teleprompter kept lagging behind and jumping around during real use.

### 1. Manual scroll release snapped the text by half the window height

`wordProgressAtCurrentOffset()` computed the resume word from the viewport **center**, but smooth-mode scrolling (`recalcCenter`) anchors the active word near the **bottom**. So releasing a trackpad scroll immediately re-anchored the center word at the bottom, jumping the text by ~half the container height. Both paths now share a single `readingAnchorY()` helper so the resume word stays where the user left it.

### 2. Zero lookahead in smooth modes

The smooth-mode anchor sat 20pt above the bottom edge, so every word past the timer position was below the window. If the speaker got even slightly ahead of the configured words/sec rate, the words they needed next were off-screen (and in silence-paused mode the timer can never catch up, so the lag compounds). The anchor now sits at 70% of the viewport height, keeping a couple of upcoming lines visible while still showing read text above.

### 3. Word tracking froze while the transcription bar kept updating

When the char-level and word-level matchers disagreed by more than the tolerance, `matchCharacters` took `min()` of the two (introduced in #37 to prevent runaway forward jumps). But the char matcher's resync can only bridge 3 characters, so a single word-level STT substitution ("sits" transcribed as "says") wedges it permanently — and from then on `min()` vetoes the word matcher's correct position forever. The user sees their words in the transcription bar while the highlight stays frozen.

Verified with `os_log` tracing during a live read: the word matcher tracked the speaker exactly (`word=187` at "following your voice") while the char matcher was stuck at `char=89` ("MacBook's"), which is exactly where the highlight froze.

Disagreements now resolve to the word-level result. Its forward movement requires consecutive fuzzy word matches, and the existing 2-of-3 agreement gate from #37 still filters transient false jumps, so the runaway failure mode that `min()` guarded against remains covered — without the freeze.

## Note on `isSpeaking`

An earlier revision of this PR added hysteresis to `isSpeaking` to stop the silence-paused timer stuttering. That's dropped: #61's adaptive noise floor solves the same problem *and* the deeper one (the fixed 0.08 threshold never triggering on low-gain mics). I've been running #61 merged with this branch locally against a real mic and it fixes Voice-Activated mode not scrolling — happy to rebase if it lands first; there's no overlap now.

## Test plan

- [x] Builds clean (arm64, Xcode 26.6)
- [x] Word tracking: highlight and scroll follow a full live read of the welcome script with no lag or freeze (log-verified positions)
- [x] Voice-activated mode: scroll keeps upcoming lines visible below the current word
- [x] Voice-activated mode: trackpad scroll + release resumes without jumping
- [x] Word-tracking anchor unchanged (active word still centered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
