### PR TITLE
Merge PR #25 (hand gesture rewind) and PR #26 (sizing/UX/shortcuts)

### DIFF
--- a/Textream/Info.plist
+++ b/Textream/Info.plist
@@ -69,5 +69,7 @@
 			</array>
 		</dict>
 	</array>
+	<key>NSCameraUsageDescription</key>
+	<string>Textream uses the camera to detect hand gestures for hands-free script control.</string>
 </dict>
 </plist>

--- a/Textream/Textream/ContentView.swift
+++ b/Textream/Textream/ContentView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 import UniformTypeIdentifiers
 import CoreImage.CIFilterBuiltins
 
+
 struct ContentView: View {
     @ObservedObject private var service = TextreamService.shared
     @State private var isRunning = false
@@ -219,63 +220,6 @@ Happy presenting! [wave]
                     )
                 )
 
-                // Bottom bar
-                VStack {
-                    Spacer()
-                    ZStack {
-                        // Waveform pill centered to full width
-                        if isRecording {
-                            waveformPill
-                                .transition(.scale(scale: 0.8).combined(with: .opacity))
-                        }
-
-                        // Buttons pinned right
-                        HStack(spacing: 10) {
-                            Spacer()
-
-                            Button {
-                                if isRecording {
-                                    stopRecording()
-                                } else {
-                                    startRecording()
-                                }
-                            } label: {
-                                Image(systemName: isRecording ? "pause.fill" : "mic.fill")
-                                    .font(.system(size: 16, weight: .semibold))
-                                    .foregroundStyle(.white)
-                                    .frame(width: 44, height: 44)
-                                    .background(isRecording ? Color.orange : Color.red)
-                                    .clipShape(Circle())
-                                    .shadow(color: .black.opacity(0.2), radius: 8, y: 4)
-                            }
-                            .buttonStyle(.plain)
-                            .disabled(isRunning)
-                            .opacity(isRunning ? 0.4 : 1)
-
-                            Button {
-                                if isRunning {
-                                    stop()
-                                } else {
-                                    run()
-                                }
-                            } label: {
-                                Image(systemName: isRunning ? "stop.fill" : "play.fill")
-                                    .font(.system(size: 16, weight: .semibold))
-                                    .foregroundStyle(.white)
-                                    .frame(width: 44, height: 44)
-                                    .background(isRunning ? Color.red : Color.accentColor)
-                                    .clipShape(Circle())
-                                    .shadow(color: .black.opacity(0.2), radius: 8, y: 4)
-                            }
-                            .buttonStyle(.plain)
-                            .disabled((!isRunning && !hasAnyContent) || isRecording)
-                            .opacity((!hasAnyContent && !isRunning) || isRecording ? 0.4 : 1)
-                        }
-                    }
-                    .padding(20)
-                }
-                .animation(.easeInOut(duration: 0.25), value: isRecording)
-
                 // Drop zone overlay — sits on top so TextEditor doesn't steal the drop
                 if isDroppingPresentation {
                 VStack(spacing: 8) {
@@ -328,6 +272,64 @@ Happy presenting! [wave]
                     return true
                 }
                 .allowsHitTesting(isDroppingPresentation)
+            }
+            .overlay(alignment: .bottom) {
+                ZStack {
+                    // Waveform pill centered to full width
+                    if isRecording {
+                        waveformPill
+                            .transition(.scale(scale: 0.8).combined(with: .opacity))
+                    }
+
+                    // Buttons pinned right
+                    HStack(spacing: 10) {
+                        Spacer()
+
+                        Button {
+                            if isRecording {
+                                stopRecording()
+                            } else {
+                                startRecording()
+                            }
+                        } label: {
+                            Image(systemName: isRecording ? "pause.fill" : "mic.fill")
+                                .font(.system(size: 16, weight: .semibold))
+                                .foregroundStyle(.white)
+                                .frame(width: 44, height: 44)
+                                .background(isRecording ? Color.orange : Color.red)
+                                .clipShape(Circle())
+                                .shadow(color: .black.opacity(0.2), radius: 8, y: 4)
+                        }
+                        .buttonStyle(.plain)
+                        .keyboardShortcut("r", modifiers: .command)
+                        .help(isRecording ? "Stop Recording (\u{2318}R)" : "Record (\u{2318}R)")
+                        .disabled(isRunning)
+                        .opacity(isRunning ? 0.4 : 1)
+
+                        Button {
+                            if isRunning {
+                                stop()
+                            } else {
+                                run()
+                            }
+                        } label: {
+                            Image(systemName: isRunning ? "stop.fill" : "text.viewfinder")
+                                .font(.system(size: 16, weight: .semibold))
+                                .foregroundStyle(.white)
+                                .frame(width: 44, height: 44)
+                                .background(isRunning ? Color.red : Color.accentColor)
+                                .clipShape(Circle())
+                                .shadow(color: .black.opacity(0.2), radius: 8, y: 4)
+                        }
+                        .buttonStyle(.plain)
+                        .keyboardShortcut(.return, modifiers: .command)
+                        .help(isRunning ? "Stop (Esc)" : "Start Teleprompter (\u{2318}\u{23CE})")
+                        .disabled((!isRunning && !hasAnyContent) || isRecording)
+                        .opacity((!hasAnyContent && !isRunning) || isRecording ? 0.4 : 1)
+                    }
+                }
+                .padding(20)
+                .animation(.easeInOut(duration: 0.25), value: isRecording)
             }
         }
     }
@@ -425,63 +427,46 @@ Happy presenting! [wave]
         .frame(minWidth: 360, minHeight: 240)
         .background(.ultraThinMaterial)
         .toolbar {
-            ToolbarItem(placement: .automatic) {
-                HStack(spacing: 8) {
-                    Button {
-                        service.openFile()
-                    } label: {
-                        HStack(spacing: 4) {
-                            if service.currentFileURL != nil && service.pages != service.savedPages {
-                                Circle()
-                                    .fill(.orange)
-                                    .frame(width: 6, height: 6)
-                            }
-                            Text(service.currentFileURL?.deletingPathExtension().lastPathComponent ?? "Untitled")
-                                .font(.system(size: 11, weight: .medium))
-                                .lineLimit(1)
-                        }
-                        .foregroundStyle(.tertiary)
+            ToolbarItem(placement: .principal) {
+                HStack(spacing: 4) {
+                    if service.currentFileURL != nil && service.pages != service.savedPages {
+                        Circle()
+                            .fill(.orange)
+                            .frame(width: 6, height: 6)
                     }
-                    .buttonStyle(.plain)
-
-                    // Add page button in toolbar
-                    Button {
-                        withAnimation(.easeInOut(duration: 0.2)) {
-                            service.pages.append("")
-                            service.currentPageIndex = service.pages.count - 1
-                        }
-                    } label: {
-                        HStack(spacing: 3) {
-                            Image(systemName: "plus")
-                                .font(.system(size: 10, weight: .semibold))
-                            Text("Page")
-                                .font(.system(size: 11, weight: .medium))
-                        }
-                        .foregroundStyle(.secondary)
-                    }
-                    .buttonStyle(.plain)
-
-                    Button {
-                        showSettings = true
-                    } label: {
-                        HStack(spacing: 4) {
-                            Image(systemName: NotchSettings.shared.listeningMode.icon)
-                                .font(.system(size: 10))
-                            Text(NotchSettings.shared.listeningMode == .wordTracking
-                                 ? languageLabel
-                                 : NotchSettings.shared.listeningMode.label)
-                                .font(.system(size: 11, weight: .medium))
-                                .lineLimit(1)
-                        }
-                        .foregroundStyle(.secondary)
-                    }
-                    .buttonStyle(.plain)
+                    TextField("Untitled", text: $service.documentTitle, onCommit: {
+                        renameFile(to: service.documentTitle)
+                    })
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.tertiary)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 200)
                 }
-                .padding(.horizontal, 8)
+                .onAppear {
+                    service.documentTitle = service.currentFileURL?.deletingPathExtension().lastPathComponent ?? "Untitled"
+                }
+                .onChange(of: service.currentFileURL) { _, url in
+                    service.documentTitle = url?.deletingPathExtension().lastPathComponent ?? "Untitled"
+                }
             }
+        }
+        .onKeyPress(.escape) {
+            if isRunning {
+                stop()
+                return .handled
+            }
+            return .ignored
         }
         .sheet(isPresented: $showSettings) {
             SettingsView(settings: NotchSettings.shared)
+        }
+        .onChange(of: showSettings) { _, isOpen in
+            DispatchQueue.main.async {
+                if let window = NSApplication.shared.mainWindow {
+                    window.level = isOpen ? NSWindow.Level(Int(CGShieldingWindowLevel()) + 2) : .normal
+                }
+            }
         }
         .sheet(isPresented: $showAbout) {
             AboutView()
@@ -590,6 +575,23 @@ Happy presenting! [wave]
     }
 
     // MARK: - Actions
+
+    private func renameFile(to newName: String) {
+        guard let url = service.currentFileURL else { return }
+        let trimmed = newName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            service.documentTitle = url.deletingPathExtension().lastPathComponent
+            return
+        }
+        let newURL = url.deletingLastPathComponent().appendingPathComponent(trimmed).appendingPathExtension(url.pathExtension)
+        guard newURL != url else { return }
+        do {
+            try FileManager.default.moveItem(at: url, to: newURL)
+            service.currentFileURL = newURL
+        } catch {
+            service.documentTitle = url.deletingPathExtension().lastPathComponent
+        }
+    }
 
     private func removePage(at index: Int) {
         guard service.pages.count > 1 else { return }

--- a/Textream/Textream/ExternalDisplayController.swift
+++ b/Textream/Textream/ExternalDisplayController.swift
@@ -214,7 +214,7 @@ struct ExternalDisplayView: View {
 
     private var prompterView: some View {
         GeometryReader { geo in
-            let fontSize = max(48, min(96, geo.size.width / 14))
+            let fontSize = NotchSettings.shared.fontSize
             let hPad = max(40, geo.size.width * 0.08)
 
             VStack(spacing: 0) {
@@ -223,7 +223,7 @@ struct ExternalDisplayView: View {
                 SpeechScrollView(
                     words: words,
                     highlightedCharCount: effectiveCharCount,
-                    font: .systemFont(ofSize: fontSize, weight: .semibold),
+                    font: NotchSettings.shared.fontFamilyPreset.font(size: fontSize),
                     highlightColor: NotchSettings.shared.fontColorPreset.color,
                     cueColor: NotchSettings.shared.cueColorPreset.color,
                     cueUnreadOpacity: NotchSettings.shared.cueBrightness.unreadOpacity,

--- a/Textream/Textream/HandGestureController.swift
+++ b/Textream/Textream/HandGestureController.swift
@@ -71,15 +71,6 @@ class HandGestureController: NSObject {
         guard session.canAddOutput(videoOutput) else { return }
         session.addOutput(videoOutput)
 
-        // Limit frame rate to ~15fps to save CPU
-        if let connection = videoOutput.connection(with: .video) {
-            connection.isEnabled = true
-        }
-        try? camera.lockForConfiguration()
-        camera.activeVideoMinFrameDuration = CMTime(value: 1, timescale: 15)
-        camera.activeVideoMaxFrameDuration = CMTime(value: 1, timescale: 15)
-        camera.unlockForConfiguration()
-
         captureSession = session
 
         processingQueue.async {

--- a/Textream/Textream/HandGestureController.swift
+++ b/Textream/Textream/HandGestureController.swift
@@ -4,77 +4,126 @@ import AppKit
 
 @Observable
 class HandGestureController: NSObject {
-    var isHandRaised: Bool = false
+    private static let logFile: FileHandle? = {
+        let path = "/tmp/textream_hand.log"
+        FileManager.default.createFile(atPath: path, contents: nil)
+        return FileHandle(forWritingAtPath: path)
+    }()
+
+    static func log(_ msg: String) {
+        let line = "\(Date()): \(msg)\n"
+        logFile?.seekToEndOfFile()
+        logFile?.write(line.data(using: .utf8)!)
+    }
+    var isHandRaised: Bool = false {
+        didSet {
+            if isHandRaised != oldValue {
+                onHandStateChanged?(isHandRaised, handHeight)
+            }
+        }
+    }
     var handHeight: Float = 0.0  // 0.0 = just above threshold, 1.0 = top of frame
 
+    /// Called on main thread when hand raise state changes. (raised, height)
+    var onHandStateChanged: ((Bool, Float) -> Void)?
+
     private var captureSession: AVCaptureSession?
-    private let videoOutput = AVCaptureVideoDataOutput()
+    private var videoOutput = AVCaptureVideoDataOutput()
     private let processingQueue = DispatchQueue(label: "com.textream.handgesture", qos: .userInteractive)
     private let handPoseRequest = VNDetectHumanHandPoseRequest()
 
-    private let raiseThreshold: Float = 0.6  // wrist Y must exceed this to count as raised
+    private let raiseThreshold: Float = 0.25  // wrist Y must exceed this to trigger raise
+    private let lowerThreshold: Float = 0.20  // wrist Y must drop below this to trigger lower (hysteresis)
     private var recentWristY: [Float] = []   // rolling buffer for smoothing
     private let smoothingWindow = 4
 
     private var isRunning = false
+    private var frameCount = 0
 
     override init() {
         super.init()
         handPoseRequest.maximumHandCount = 2
+        Self.log("[HandGesture] init()")
     }
 
     func start() {
-        guard !isRunning else { return }
+        guard !isRunning else {
+            Self.log("[HandGesture] start() skipped — already running")
+            return
+        }
 
-        // Check camera permission
-        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        let status = AVCaptureDevice.authorizationStatus(for: .video)
+        Self.log("[HandGesture] start() called, auth status=\(status.rawValue)")
+        switch status {
         case .authorized:
             setupAndStart()
         case .notDetermined:
             AVCaptureDevice.requestAccess(for: .video) { [weak self] granted in
+                Self.log("[HandGesture] camera permission granted=\(granted)")
                 if granted {
                     DispatchQueue.main.async { self?.setupAndStart() }
                 }
             }
         default:
-            // Permission denied or restricted — silently disable
+            Self.log("[HandGesture] camera permission denied/restricted")
             return
         }
     }
 
     func stop() {
         guard isRunning else { return }
+        Self.log("[HandGesture] stop()")
+        // Clear callback first to prevent triggering rewind logic during teardown
+        let savedCallback = onHandStateChanged
+        onHandStateChanged = nil
+
         captureSession?.stopRunning()
+        captureSession = nil  // release session so videoOutput can be re-added later
         isRunning = false
         isHandRaised = false
         handHeight = 0.0
         recentWristY = []
+
+        // Restore callback for next start
+        onHandStateChanged = savedCallback
     }
 
     private func setupAndStart() {
+        Self.log("[HandGesture] setupAndStart()")
         let session = AVCaptureSession()
-        session.sessionPreset = .low  // ~640x480, minimal resource usage
+        session.sessionPreset = .low
 
-        // Find front-facing camera
         guard let camera = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: .front)
                 ?? AVCaptureDevice.default(for: .video) else {
-            // No camera available — silently disable
+            Self.log("[HandGesture] No camera found")
             return
         }
+        Self.log("[HandGesture] Using camera: \(camera.localizedName)")
 
-        guard let input = try? AVCaptureDeviceInput(device: camera) else { return }
-        guard session.canAddInput(input) else { return }
+        guard let input = try? AVCaptureDeviceInput(device: camera) else {
+            Self.log("[HandGesture] Failed to create camera input")
+            return
+        }
+        guard session.canAddInput(input) else {
+            Self.log("[HandGesture] Cannot add input to session")
+            return
+        }
         session.addInput(input)
 
+        videoOutput = AVCaptureVideoDataOutput()
         videoOutput.setSampleBufferDelegate(self, queue: processingQueue)
         videoOutput.alwaysDiscardsLateVideoFrames = true
-        guard session.canAddOutput(videoOutput) else { return }
+        guard session.canAddOutput(videoOutput) else {
+            Self.log("[HandGesture] Cannot add output to session")
+            return
+        }
         session.addOutput(videoOutput)
 
         captureSession = session
 
         processingQueue.async {
             session.startRunning()
+            Self.log("[HandGesture] session.startRunning() completed")
         }
         isRunning = true
     }
@@ -82,6 +131,10 @@ class HandGestureController: NSObject {
 
 extension HandGestureController: AVCaptureVideoDataOutputSampleBufferDelegate {
     func captureOutput(_ output: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection) {
+        frameCount += 1
+        if frameCount % 30 == 1 {
+            Self.log("[HandGesture] frame \(frameCount) received")
+        }
         guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
 
         let handler = VNImageRequestHandler(cvPixelBuffer: pixelBuffer, orientation: .up, options: [:])
@@ -99,7 +152,8 @@ extension HandGestureController: AVCaptureVideoDataOutputSampleBufferDelegate {
         for hand in results {
             if let wrist = try? hand.recognizedPoint(.wrist),
                wrist.confidence > 0.3 {
-                let y = Float(wrist.location.y)  // Vision coords: 0=bottom, 1=top
+                let y = Float(wrist.location.y)
+                Self.log("[HandGesture] wrist y=\(String(format: "%.3f", y)) conf=\(String(format: "%.2f", wrist.confidence))")
                 if y > highestWristY {
                     highestWristY = y
                 }
@@ -113,27 +167,30 @@ extension HandGestureController: AVCaptureVideoDataOutputSampleBufferDelegate {
 
     private func updateWristPosition(_ wristY: Float?) {
         guard let y = wristY else {
-            // No hand detected — decay smoothly
             recentWristY = []
-            isHandRaised = false
             handHeight = 0.0
+            isHandRaised = false  // set after height so callback has correct height
             return
         }
 
-        // Smooth with rolling average
         recentWristY.append(y)
         if recentWristY.count > smoothingWindow {
             recentWristY.removeFirst()
         }
         let smoothed = recentWristY.reduce(0, +) / Float(recentWristY.count)
 
-        if smoothed > raiseThreshold {
+        // Hysteresis: raise at raiseThreshold, lower at lowerThreshold
+        if !isHandRaised && smoothed > raiseThreshold {
+            Self.log("[HandGesture] HAND RAISED (smoothed=\(String(format: "%.3f", smoothed)))")
+            handHeight = min(1.0, (smoothed - lowerThreshold) / (1.0 - lowerThreshold))
             isHandRaised = true
-            // Map threshold..1.0 → 0.0..1.0
-            handHeight = min(1.0, (smoothed - raiseThreshold) / (1.0 - raiseThreshold))
-        } else {
-            isHandRaised = false
+        } else if isHandRaised && smoothed < lowerThreshold {
+            Self.log("[HandGesture] HAND LOWERED (smoothed=\(String(format: "%.3f", smoothed)))")
             handHeight = 0.0
+            isHandRaised = false
+        } else if isHandRaised {
+            // Update height while raised (for speed control)
+            handHeight = min(1.0, (smoothed - lowerThreshold) / (1.0 - lowerThreshold))
         }
     }
 }

--- a/Textream/Textream/HandGestureController.swift
+++ b/Textream/Textream/HandGestureController.swift
@@ -1,0 +1,148 @@
+import AVFoundation
+import Vision
+import AppKit
+
+@Observable
+class HandGestureController: NSObject {
+    var isHandRaised: Bool = false
+    var handHeight: Float = 0.0  // 0.0 = just above threshold, 1.0 = top of frame
+
+    private var captureSession: AVCaptureSession?
+    private let videoOutput = AVCaptureVideoDataOutput()
+    private let processingQueue = DispatchQueue(label: "com.textream.handgesture", qos: .userInteractive)
+    private let handPoseRequest = VNDetectHumanHandPoseRequest()
+
+    private let raiseThreshold: Float = 0.6  // wrist Y must exceed this to count as raised
+    private var recentWristY: [Float] = []   // rolling buffer for smoothing
+    private let smoothingWindow = 4
+
+    private var isRunning = false
+
+    override init() {
+        super.init()
+        handPoseRequest.maximumHandCount = 2
+    }
+
+    func start() {
+        guard !isRunning else { return }
+
+        // Check camera permission
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        case .authorized:
+            setupAndStart()
+        case .notDetermined:
+            AVCaptureDevice.requestAccess(for: .video) { [weak self] granted in
+                if granted {
+                    DispatchQueue.main.async { self?.setupAndStart() }
+                }
+            }
+        default:
+            // Permission denied or restricted — silently disable
+            return
+        }
+    }
+
+    func stop() {
+        guard isRunning else { return }
+        captureSession?.stopRunning()
+        isRunning = false
+        isHandRaised = false
+        handHeight = 0.0
+        recentWristY = []
+    }
+
+    private func setupAndStart() {
+        let session = AVCaptureSession()
+        session.sessionPreset = .low  // ~640x480, minimal resource usage
+
+        // Find front-facing camera
+        guard let camera = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: .front)
+                ?? AVCaptureDevice.default(for: .video) else {
+            // No camera available — silently disable
+            return
+        }
+
+        guard let input = try? AVCaptureDeviceInput(device: camera) else { return }
+        guard session.canAddInput(input) else { return }
+        session.addInput(input)
+
+        videoOutput.setSampleBufferDelegate(self, queue: processingQueue)
+        videoOutput.alwaysDiscardsLateVideoFrames = true
+        guard session.canAddOutput(videoOutput) else { return }
+        session.addOutput(videoOutput)
+
+        // Limit frame rate to ~15fps to save CPU
+        if let connection = videoOutput.connection(with: .video) {
+            connection.isEnabled = true
+        }
+        try? camera.lockForConfiguration()
+        camera.activeVideoMinFrameDuration = CMTime(value: 1, timescale: 15)
+        camera.activeVideoMaxFrameDuration = CMTime(value: 1, timescale: 15)
+        camera.unlockForConfiguration()
+
+        captureSession = session
+
+        processingQueue.async {
+            session.startRunning()
+        }
+        isRunning = true
+    }
+}
+
+extension HandGestureController: AVCaptureVideoDataOutputSampleBufferDelegate {
+    func captureOutput(_ output: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection) {
+        guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
+
+        let handler = VNImageRequestHandler(cvPixelBuffer: pixelBuffer, orientation: .up, options: [:])
+        try? handler.perform([handPoseRequest])
+
+        guard let results = handPoseRequest.results, !results.isEmpty else {
+            DispatchQueue.main.async {
+                self.updateWristPosition(nil)
+            }
+            return
+        }
+
+        // Find the hand with the highest wrist Y
+        var highestWristY: Float = 0
+        for hand in results {
+            if let wrist = try? hand.recognizedPoint(.wrist),
+               wrist.confidence > 0.3 {
+                let y = Float(wrist.location.y)  // Vision coords: 0=bottom, 1=top
+                if y > highestWristY {
+                    highestWristY = y
+                }
+            }
+        }
+
+        DispatchQueue.main.async {
+            self.updateWristPosition(highestWristY > 0 ? highestWristY : nil)
+        }
+    }
+
+    private func updateWristPosition(_ wristY: Float?) {
+        guard let y = wristY else {
+            // No hand detected — decay smoothly
+            recentWristY = []
+            isHandRaised = false
+            handHeight = 0.0
+            return
+        }
+
+        // Smooth with rolling average
+        recentWristY.append(y)
+        if recentWristY.count > smoothingWindow {
+            recentWristY.removeFirst()
+        }
+        let smoothed = recentWristY.reduce(0, +) / Float(recentWristY.count)
+
+        if smoothed > raiseThreshold {
+            isHandRaised = true
+            // Map threshold..1.0 → 0.0..1.0
+            handHeight = min(1.0, (smoothed - raiseThreshold) / (1.0 - raiseThreshold))
+        } else {
+            isHandRaised = false
+            handHeight = 0.0
+        }
+    }
+}

--- a/Textream/Textream/NotchOverlayController.swift
+++ b/Textream/Textream/NotchOverlayController.swift
@@ -122,10 +122,12 @@ class NotchOverlayController: NSObject {
             speechRecognizer.start(with: text)
         }
 
-        handGestureController.onHandStateChanged = { [weak self] raised, height in
-            self?.handleHandGesture(raised: raised, height: height)
+        if settings.handGestureRewind {
+            handGestureController.onHandStateChanged = { [weak self] raised, height in
+                self?.handleHandGesture(raised: raised, height: height)
+            }
+            handGestureController.start()
         }
-        handGestureController.start()
     }
 
     private func handleHandGesture(raised: Bool, height: Float) {
@@ -223,7 +225,9 @@ class NotchOverlayController: NSObject {
             speechRecognizer.start(with: text)
         }
 
-        handGestureController.start()
+        if NotchSettings.shared.handGestureRewind {
+            handGestureController.start()
+        }
     }
 
     private func screenUnderMouse() -> NSScreen? {

--- a/Textream/Textream/NotchOverlayController.swift
+++ b/Textream/Textream/NotchOverlayController.swift
@@ -47,6 +47,10 @@ class OverlayContent {
 class NotchOverlayController: NSObject {
     private var panel: NSPanel?
     let speechRecognizer = SpeechRecognizer()
+    let handGestureController = HandGestureController()
+    private var rewindTimer: Timer?
+    private var indicatorWindow: NSWindow?
+    private var indicatorView: NSHostingView<HandIndicatorView>?
     let overlayContent = OverlayContent()
     var onComplete: (() -> Void)?
     var onNextPage: (() -> Void)?
@@ -108,6 +112,22 @@ class NotchOverlayController: NSObject {
             }
         }
 
+        // Live-update panel size when dimension sliders change
+        // Track last known values to only react to actual changes
+        var lastWidth = settings.windowWidthPercent
+        var lastHeight = settings.windowHeightPercent
+        Timer.publish(every: 0.1, on: .main, in: .common)
+            .autoconnect()
+            .sink { [weak self] _ in
+                let s = NotchSettings.shared
+                if s.windowWidthPercent != lastWidth || s.windowHeightPercent != lastHeight {
+                    lastWidth = s.windowWidthPercent
+                    lastHeight = s.windowHeightPercent
+                    self?.updatePanelSize()
+                }
+            }
+            .store(in: &cancellables)
+
         // Show floating stop button only in follow-cursor mode (panel ignores mouse events)
         if settings.overlayMode == .floating && settings.followCursorWhenUndocked {
             showStopButton(on: screen)
@@ -117,6 +137,89 @@ class NotchOverlayController: NSObject {
         if settings.listeningMode != .classic {
             speechRecognizer.start(with: text)
         }
+
+        handGestureController.onHandStateChanged = { [weak self] raised, height in
+            self?.handleHandGesture(raised: raised, height: height)
+        }
+        handGestureController.start()
+    }
+
+    private func handleHandGesture(raised: Bool, height: Float) {
+        guard panel != nil else { return }
+        let settings = NotchSettings.shared
+        HandGestureController.log("[Controller] handleHandGesture raised=\(raised) height=\(height) mode=\(settings.listeningMode.rawValue)")
+
+        if raised {
+            showHandIndicator()
+
+            // Pause current mode
+            speechRecognizer.pauseForRewind()
+
+            // Start rewind timer
+            rewindTimer?.invalidate()
+            rewindTimer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: true) { [weak self] _ in
+                guard let self else { return }
+                let h = self.handGestureController.handHeight
+                let words: Int
+                if h < 0.3 { words = 1 }
+                else if h < 0.7 { words = 2 }
+                else { words = 4 }
+
+                self.speechRecognizer.rewindByWords(words)
+            }
+        } else {
+            HandGestureController.log("[Controller] hiding indicator, window=\(indicatorWindow != nil)")
+            hideHandIndicator()
+
+            // Stop rewind
+            rewindTimer?.invalidate()
+            rewindTimer = nil
+
+            HandGestureController.log("[Controller] calling resumeAfterRewind, isListening=\(speechRecognizer.isListening)")
+            switch settings.listeningMode {
+            case .wordTracking:
+                speechRecognizer.resumeAfterRewind()
+                HandGestureController.log("[Controller] resumeAfterRewind called, isListening=\(speechRecognizer.isListening)")
+            case .classic, .silencePaused:
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { [weak self] in
+                    self?.speechRecognizer.resumeAfterRewind()
+                }
+            }
+        }
+    }
+
+    private func showHandIndicator() {
+        guard indicatorWindow == nil else { return }
+        guard let screen = NSScreen.main ?? NSScreen.screens.first else { return }
+
+        let size: CGFloat = 60
+        let margin: CGFloat = 20
+        let frame = NSRect(
+            x: screen.frame.maxX - size - margin,
+            y: screen.frame.maxY - size - margin - 30,  // below menu bar
+            width: size,
+            height: size
+        )
+
+        let window = NSWindow(contentRect: frame, styleMask: .borderless, backing: .buffered, defer: false)
+        window.isOpaque = false
+        window.backgroundColor = .clear
+        window.level = NSWindow.Level(Int(CGShieldingWindowLevel()) + 1)
+        window.ignoresMouseEvents = true
+        window.hasShadow = false
+
+        let hostView = NSHostingView(rootView: HandIndicatorView(isRewinding: true))
+        window.contentView = hostView
+        window.orderFront(nil)
+
+        indicatorWindow = window
+        indicatorView = hostView
+    }
+
+    private func hideHandIndicator() {
+        indicatorWindow?.orderOut(nil)
+        indicatorWindow = nil
+        indicatorView = nil
     }
 
     func updateContent(text: String, hasNextPage: Bool) {
@@ -136,6 +239,8 @@ class NotchOverlayController: NSObject {
         if settings.listeningMode != .classic {
             speechRecognizer.start(with: text)
         }
+
+        handGestureController.start()
     }
 
     private func screenUnderMouse() -> NSScreen? {
@@ -213,10 +318,10 @@ class NotchOverlayController: NSObject {
     }
 
     private func showPinned(settings: NotchSettings, screen: NSScreen) {
-        let notchWidth = settings.notchWidth
-        let textAreaHeight = settings.textAreaHeight
-        let maxExtraHeight: CGFloat = 350
         let screenFrame = screen.frame
+        let textAreaHeight = screenFrame.height * settings.windowHeightPercent
+        let maxExtraHeight: CGFloat = 350
+        let notchWidth = screenFrame.width * settings.windowWidthPercent
         let visibleFrame = screen.visibleFrame
 
         // Menu bar / notch height from top of screen
@@ -232,7 +337,7 @@ class NotchOverlayController: NSObject {
         self.frameTracker = tracker
         self.currentScreenID = screen.displayID
 
-        let overlayView = NotchOverlayView(content: overlayContent, speechRecognizer: speechRecognizer, menuBarHeight: menuBarHeight, baseTextHeight: textAreaHeight, maxExtraHeight: maxExtraHeight, frameTracker: tracker)
+        let overlayView = NotchOverlayView(content: overlayContent, speechRecognizer: speechRecognizer, handGesture: handGestureController, menuBarHeight: menuBarHeight, baseTextHeight: textAreaHeight, maxExtraHeight: maxExtraHeight, frameTracker: tracker)
         let contentView = NSHostingView(rootView: overlayView)
 
         // Start panel at full target size (SwiftUI animates the notch shape inside)
@@ -259,6 +364,8 @@ class NotchOverlayController: NSObject {
         panel.orderFrontRegardless()
         self.panel = panel
 
+        installKeyMonitor()
+
         // Start mouse tracking for follow-mouse mode
         if settings.notchDisplayMode == .followMouse {
             startMouseTracking()
@@ -266,8 +373,8 @@ class NotchOverlayController: NSObject {
     }
 
     private func showFollowCursor(settings: NotchSettings, screen: NSScreen) {
-        let panelWidth = settings.notchWidth
-        let panelHeight = settings.textAreaHeight
+        let panelWidth = screen.frame.width * settings.windowWidthPercent
+        let panelHeight = screen.frame.height * settings.windowHeightPercent
 
         let mouse = NSEvent.mouseLocation
         let cursorOffset: CGFloat = 8
@@ -277,6 +384,7 @@ class NotchOverlayController: NSObject {
         let floatingView = FloatingOverlayView(
             content: overlayContent,
             speechRecognizer: speechRecognizer,
+            handGesture: handGestureController,
             baseHeight: panelHeight,
             followingCursor: true
         )
@@ -336,8 +444,8 @@ class NotchOverlayController: NSObject {
     }
 
     private func showFloating(settings: NotchSettings, screenFrame: CGRect) {
-        let panelWidth = settings.notchWidth
-        let panelHeight = settings.textAreaHeight
+        let panelWidth = screenFrame.width * settings.windowWidthPercent
+        let panelHeight = screenFrame.height * settings.windowHeightPercent
 
         let xPosition = screenFrame.midX - panelWidth / 2
         let yPosition = screenFrame.midY - panelHeight / 2 + 100
@@ -345,6 +453,7 @@ class NotchOverlayController: NSObject {
         let floatingView = FloatingOverlayView(
             content: overlayContent,
             speechRecognizer: speechRecognizer,
+            handGesture: handGestureController,
             baseHeight: panelHeight
         )
         let contentView = NSHostingView(rootView: floatingView)
@@ -362,8 +471,8 @@ class NotchOverlayController: NSObject {
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
         panel.ignoresMouseEvents = false
         panel.isMovableByWindowBackground = true
-        panel.minSize = NSSize(width: 280, height: panelHeight)
-        panel.maxSize = NSSize(width: 500, height: panelHeight + 350)
+        panel.minSize = NSSize(width: screenFrame.width * 0.2, height: panelHeight)
+        panel.maxSize = NSSize(width: screenFrame.width * 0.8, height: panelHeight + 350)
         panel.sharingType = NotchSettings.shared.hideFromScreenShare ? .none : .readOnly
         panel.contentView = contentView
 
@@ -373,10 +482,59 @@ class NotchOverlayController: NSObject {
         installKeyMonitor()
     }
 
+    private func updatePanelSize() {
+        guard let panel = panel else { return }
+        let settings = NotchSettings.shared
+        guard settings.overlayMode != .fullscreen else { return }
+        guard let screen = panel.screen ?? NSScreen.main else { return }
+        let screenFrame = screen.frame
+        let newWidth = screenFrame.width * settings.windowWidthPercent
+        let newHeight = screenFrame.height * settings.windowHeightPercent
+
+        var frame = panel.frame
+
+        switch settings.overlayMode {
+        case .pinned:
+            let visibleFrame = screen.visibleFrame
+            let menuBarHeight = screenFrame.maxY - visibleFrame.maxY
+            let totalHeight = menuBarHeight + newHeight
+            frame.origin.x = screenFrame.midX - newWidth / 2
+            frame.origin.y = screenFrame.maxY - totalHeight
+            frame.size.width = newWidth
+            frame.size.height = totalHeight
+            panel.setFrame(frame, display: true, animate: false)
+
+            if let tracker = frameTracker {
+                tracker.visibleWidth = newWidth
+                tracker.visibleHeight = totalHeight
+            }
+
+        case .floating:
+            let centerX = frame.midX
+            let centerY = frame.midY
+            frame.origin.x = centerX - newWidth / 2
+            frame.origin.y = centerY - newHeight / 2
+            frame.size.width = newWidth
+            frame.size.height = newHeight
+            panel.setFrame(frame, display: true, animate: false)
+
+            panel.minSize = NSSize(width: screenFrame.width * 0.2, height: screenFrame.height * 0.05)
+            panel.maxSize = NSSize(width: screenFrame.width * 0.8, height: screenFrame.height * 0.5)
+
+        case .fullscreen:
+            break
+        }
+    }
+
     func dismiss() {
         // Trigger the shrink animation
         speechRecognizer.shouldDismiss = true
         speechRecognizer.forceStop()
+        handGestureController.onHandStateChanged = nil
+        handGestureController.stop()
+        hideHandIndicator()
+        rewindTimer?.invalidate()
+        rewindTimer = nil
 
         // Wait for animation, then remove panel
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) { [weak self] in
@@ -415,6 +573,11 @@ class NotchOverlayController: NSObject {
         removeEscMonitor()
         cancellables.removeAll()
         speechRecognizer.forceStop()
+        handGestureController.onHandStateChanged = nil
+        handGestureController.stop()
+        hideHandIndicator()
+        rewindTimer?.invalidate()
+        rewindTimer = nil
         speechRecognizer.recognizedCharCount = 0
         panel?.orderOut(nil)
         panel = nil
@@ -600,11 +763,49 @@ struct DynamicIslandShape: Shape {
     }
 }
 
+// MARK: - Hand Gesture Indicator
+
+struct HandIndicatorView: View {
+    let isRewinding: Bool
+
+    @State private var rotation: Double = 0
+
+    var body: some View {
+        ZStack {
+            // Background circle
+            Circle()
+                .stroke(Color.white.opacity(0.3), lineWidth: 3)
+                .frame(width: 44, height: 44)
+
+            // Animated arc
+            Circle()
+                .trim(from: 0, to: 0.7)
+                .stroke(Color.green, style: StrokeStyle(lineWidth: 3, lineCap: .round))
+                .frame(width: 44, height: 44)
+                .rotationEffect(.degrees(rotation))
+
+            // Rewind icon
+            Image(systemName: "backward.fill")
+                .font(.system(size: 16, weight: .bold))
+                .foregroundColor(.green)
+        }
+        .frame(width: 60, height: 60)
+        .background(Color.black.opacity(0.6))
+        .clipShape(Circle())
+        .onAppear {
+            withAnimation(.linear(duration: 1).repeatForever(autoreverses: false)) {
+                rotation = -360
+            }
+        }
+    }
+}
+
 // MARK: - Overlay SwiftUI View
 
 struct NotchOverlayView: View {
     @Bindable var content: OverlayContent
     @Bindable var speechRecognizer: SpeechRecognizer
+    var handGesture: HandGestureController
     let menuBarHeight: CGFloat
     let baseTextHeight: CGFloat
     let maxExtraHeight: CGFloat
@@ -627,6 +828,8 @@ struct NotchOverlayView: View {
     @State private var isUserScrolling: Bool = false
     private let scrollTimer = Timer.publish(every: 0.05, on: .main, in: .common).autoconnect()
 
+    // Hand-gesture rewind state
+
     // Auto next page countdown
     @State private var countdownRemaining: Int = 0
     @State private var countdownTimer: Timer? = nil
@@ -641,6 +844,7 @@ struct NotchOverlayView: View {
     private var listeningMode: ListeningMode {
         NotchSettings.shared.listeningMode
     }
+
 
     /// Convert fractional word index to char offset using actual word lengths
     private func charOffsetForWordProgress(_ progress: Double) -> Int {
@@ -802,7 +1006,7 @@ struct NotchOverlayView: View {
 
     private func updateFrameTracker() {
         let targetHeight = menuBarHeight + baseTextHeight + extraHeight
-        let fullWidth = NotchSettings.shared.notchWidth
+        let fullWidth = (NSScreen.main?.frame.width ?? 1440) * NotchSettings.shared.windowWidthPercent
         frameTracker.visibleHeight = targetHeight
         frameTracker.visibleWidth = fullWidth
     }
@@ -1136,6 +1340,7 @@ struct GlassEffectView: NSViewRepresentable {
 struct FloatingOverlayView: View {
     @Bindable var content: OverlayContent
     @Bindable var speechRecognizer: SpeechRecognizer
+    var handGesture: HandGestureController
     let baseHeight: CGFloat
     var followingCursor: Bool = false
 
@@ -1155,9 +1360,12 @@ struct FloatingOverlayView: View {
     @State private var isUserScrolling: Bool = false
     private let scrollTimer = Timer.publish(every: 0.05, on: .main, in: .common).autoconnect()
 
+    // Hand-gesture rewind state
+
     private var listeningMode: ListeningMode {
         NotchSettings.shared.listeningMode
     }
+
 
     /// Convert fractional word index to char offset using actual word lengths
     private func charOffsetForWordProgress(_ progress: Double) -> Int {

--- a/Textream/Textream/NotchOverlayController.swift
+++ b/Textream/Textream/NotchOverlayController.swift
@@ -47,6 +47,7 @@ class OverlayContent {
 class NotchOverlayController: NSObject {
     private var panel: NSPanel?
     let speechRecognizer = SpeechRecognizer()
+    let handGestureController = HandGestureController()
     let overlayContent = OverlayContent()
     var onComplete: (() -> Void)?
     var onNextPage: (() -> Void)?
@@ -117,6 +118,8 @@ class NotchOverlayController: NSObject {
         if settings.listeningMode != .classic {
             speechRecognizer.start(with: text)
         }
+
+        handGestureController.start()
     }
 
     func updateContent(text: String, hasNextPage: Bool) {
@@ -136,6 +139,8 @@ class NotchOverlayController: NSObject {
         if settings.listeningMode != .classic {
             speechRecognizer.start(with: text)
         }
+
+        handGestureController.start()
     }
 
     private func screenUnderMouse() -> NSScreen? {
@@ -232,7 +237,7 @@ class NotchOverlayController: NSObject {
         self.frameTracker = tracker
         self.currentScreenID = screen.displayID
 
-        let overlayView = NotchOverlayView(content: overlayContent, speechRecognizer: speechRecognizer, menuBarHeight: menuBarHeight, baseTextHeight: textAreaHeight, maxExtraHeight: maxExtraHeight, frameTracker: tracker)
+        let overlayView = NotchOverlayView(content: overlayContent, speechRecognizer: speechRecognizer, handGesture: handGestureController, menuBarHeight: menuBarHeight, baseTextHeight: textAreaHeight, maxExtraHeight: maxExtraHeight, frameTracker: tracker)
         let contentView = NSHostingView(rootView: overlayView)
 
         // Start panel at full target size (SwiftUI animates the notch shape inside)
@@ -277,6 +282,7 @@ class NotchOverlayController: NSObject {
         let floatingView = FloatingOverlayView(
             content: overlayContent,
             speechRecognizer: speechRecognizer,
+            handGesture: handGestureController,
             baseHeight: panelHeight,
             followingCursor: true
         )
@@ -345,6 +351,7 @@ class NotchOverlayController: NSObject {
         let floatingView = FloatingOverlayView(
             content: overlayContent,
             speechRecognizer: speechRecognizer,
+            handGesture: handGestureController,
             baseHeight: panelHeight
         )
         let contentView = NSHostingView(rootView: floatingView)
@@ -377,6 +384,7 @@ class NotchOverlayController: NSObject {
         // Trigger the shrink animation
         speechRecognizer.shouldDismiss = true
         speechRecognizer.forceStop()
+        handGestureController.stop()
 
         // Wait for animation, then remove panel
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) { [weak self] in
@@ -415,6 +423,7 @@ class NotchOverlayController: NSObject {
         removeEscMonitor()
         cancellables.removeAll()
         speechRecognizer.forceStop()
+        handGestureController.stop()
         speechRecognizer.recognizedCharCount = 0
         panel?.orderOut(nil)
         panel = nil
@@ -605,6 +614,7 @@ struct DynamicIslandShape: Shape {
 struct NotchOverlayView: View {
     @Bindable var content: OverlayContent
     @Bindable var speechRecognizer: SpeechRecognizer
+    var handGesture: HandGestureController
     let menuBarHeight: CGFloat
     let baseTextHeight: CGFloat
     let maxExtraHeight: CGFloat
@@ -627,6 +637,10 @@ struct NotchOverlayView: View {
     @State private var isUserScrolling: Bool = false
     private let scrollTimer = Timer.publish(every: 0.05, on: .main, in: .common).autoconnect()
 
+    // Hand-gesture rewind state
+    @State private var rewindTimer: Timer?
+    @State private var resumeDelay: DispatchWorkItem?
+
     // Auto next page countdown
     @State private var countdownRemaining: Int = 0
     @State private var countdownTimer: Timer? = nil
@@ -640,6 +654,12 @@ struct NotchOverlayView: View {
 
     private var listeningMode: ListeningMode {
         NotchSettings.shared.listeningMode
+    }
+
+    private func rewindWordsPerTick(handHeight: Float) -> Int {
+        if handHeight < 0.3 { return 1 }
+        if handHeight < 0.7 { return 2 }
+        return 4
     }
 
     /// Convert fractional word index to char offset using actual word lengths
@@ -797,6 +817,55 @@ struct NotchOverlayView: View {
         }
         .onChange(of: content.totalCharCount) { _, _ in
             timerWordProgress = 0
+        }
+        .onChange(of: handGesture.isHandRaised) { _, raised in
+            if raised {
+                resumeDelay?.cancel()
+                resumeDelay = nil
+
+                switch listeningMode {
+                case .wordTracking:
+                    speechRecognizer.pauseForRewind()
+                case .classic:
+                    isPaused = true
+                case .silencePaused:
+                    speechRecognizer.pauseForRewind()
+                    isPaused = true
+                }
+
+                rewindTimer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: true) { _ in
+                    let words = rewindWordsPerTick(handHeight: handGesture.handHeight)
+                    switch listeningMode {
+                    case .wordTracking:
+                        speechRecognizer.rewindByWords(words)
+                    case .classic, .silencePaused:
+                        timerWordProgress = max(0, timerWordProgress - Double(words))
+                    }
+                }
+            } else {
+                rewindTimer?.invalidate()
+                rewindTimer = nil
+
+                switch listeningMode {
+                case .wordTracking:
+                    speechRecognizer.resumeAfterRewind()
+                case .classic:
+                    let work = DispatchWorkItem { isPaused = false }
+                    resumeDelay = work
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: work)
+                case .silencePaused:
+                    speechRecognizer.resumeAfterRewind()
+                    let work = DispatchWorkItem { isPaused = false }
+                    resumeDelay = work
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: work)
+                }
+            }
+        }
+        .onDisappear {
+            rewindTimer?.invalidate()
+            rewindTimer = nil
+            resumeDelay?.cancel()
+            resumeDelay = nil
         }
     }
 
@@ -1136,6 +1205,7 @@ struct GlassEffectView: NSViewRepresentable {
 struct FloatingOverlayView: View {
     @Bindable var content: OverlayContent
     @Bindable var speechRecognizer: SpeechRecognizer
+    var handGesture: HandGestureController
     let baseHeight: CGFloat
     var followingCursor: Bool = false
 
@@ -1155,8 +1225,18 @@ struct FloatingOverlayView: View {
     @State private var isUserScrolling: Bool = false
     private let scrollTimer = Timer.publish(every: 0.05, on: .main, in: .common).autoconnect()
 
+    // Hand-gesture rewind state
+    @State private var rewindTimer: Timer?
+    @State private var resumeDelay: DispatchWorkItem?
+
     private var listeningMode: ListeningMode {
         NotchSettings.shared.listeningMode
+    }
+
+    private func rewindWordsPerTick(handHeight: Float) -> Int {
+        if handHeight < 0.3 { return 1 }
+        if handHeight < 0.7 { return 2 }
+        return 4
     }
 
     /// Convert fractional word index to char offset using actual word lengths
@@ -1291,6 +1371,55 @@ struct FloatingOverlayView: View {
         }
         .onChange(of: content.totalCharCount) { _, _ in
             timerWordProgress = 0
+        }
+        .onChange(of: handGesture.isHandRaised) { _, raised in
+            if raised {
+                resumeDelay?.cancel()
+                resumeDelay = nil
+
+                switch listeningMode {
+                case .wordTracking:
+                    speechRecognizer.pauseForRewind()
+                case .classic:
+                    isPaused = true
+                case .silencePaused:
+                    speechRecognizer.pauseForRewind()
+                    isPaused = true
+                }
+
+                rewindTimer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: true) { _ in
+                    let words = rewindWordsPerTick(handHeight: handGesture.handHeight)
+                    switch listeningMode {
+                    case .wordTracking:
+                        speechRecognizer.rewindByWords(words)
+                    case .classic, .silencePaused:
+                        timerWordProgress = max(0, timerWordProgress - Double(words))
+                    }
+                }
+            } else {
+                rewindTimer?.invalidate()
+                rewindTimer = nil
+
+                switch listeningMode {
+                case .wordTracking:
+                    speechRecognizer.resumeAfterRewind()
+                case .classic:
+                    let work = DispatchWorkItem { isPaused = false }
+                    resumeDelay = work
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: work)
+                case .silencePaused:
+                    speechRecognizer.resumeAfterRewind()
+                    let work = DispatchWorkItem { isPaused = false }
+                    resumeDelay = work
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: work)
+                }
+            }
+        }
+        .onDisappear {
+            rewindTimer?.invalidate()
+            rewindTimer = nil
+            resumeDelay?.cancel()
+            resumeDelay = nil
         }
     }
 

--- a/Textream/Textream/NotchOverlayController.swift
+++ b/Textream/Textream/NotchOverlayController.swift
@@ -48,6 +48,9 @@ class NotchOverlayController: NSObject {
     private var panel: NSPanel?
     let speechRecognizer = SpeechRecognizer()
     let handGestureController = HandGestureController()
+    private var rewindTimer: Timer?
+    private var indicatorWindow: NSWindow?
+    private var indicatorView: NSHostingView<HandIndicatorView>?
     let overlayContent = OverlayContent()
     var onComplete: (() -> Void)?
     var onNextPage: (() -> Void)?
@@ -119,7 +122,87 @@ class NotchOverlayController: NSObject {
             speechRecognizer.start(with: text)
         }
 
+        handGestureController.onHandStateChanged = { [weak self] raised, height in
+            self?.handleHandGesture(raised: raised, height: height)
+        }
         handGestureController.start()
+    }
+
+    private func handleHandGesture(raised: Bool, height: Float) {
+        let settings = NotchSettings.shared
+        HandGestureController.log("[Controller] handleHandGesture raised=\(raised) height=\(height) mode=\(settings.listeningMode.rawValue)")
+
+        if raised {
+            showHandIndicator()
+
+            // Pause current mode
+            speechRecognizer.pauseForRewind()
+
+            // Start rewind timer
+            rewindTimer?.invalidate()
+            rewindTimer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: true) { [weak self] _ in
+                guard let self else { return }
+                let h = self.handGestureController.handHeight
+                let words: Int
+                if h < 0.3 { words = 1 }
+                else if h < 0.7 { words = 2 }
+                else { words = 4 }
+
+                self.speechRecognizer.rewindByWords(words)
+            }
+        } else {
+            HandGestureController.log("[Controller] hiding indicator, window=\(indicatorWindow != nil)")
+            hideHandIndicator()
+
+            // Stop rewind
+            rewindTimer?.invalidate()
+            rewindTimer = nil
+
+            HandGestureController.log("[Controller] calling resumeAfterRewind, isListening=\(speechRecognizer.isListening)")
+            switch settings.listeningMode {
+            case .wordTracking:
+                speechRecognizer.resumeAfterRewind()
+                HandGestureController.log("[Controller] resumeAfterRewind called, isListening=\(speechRecognizer.isListening)")
+            case .classic, .silencePaused:
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { [weak self] in
+                    self?.speechRecognizer.resumeAfterRewind()
+                }
+            }
+        }
+    }
+
+    private func showHandIndicator() {
+        guard indicatorWindow == nil else { return }
+        guard let screen = NSScreen.main ?? NSScreen.screens.first else { return }
+
+        let size: CGFloat = 60
+        let margin: CGFloat = 20
+        let frame = NSRect(
+            x: screen.frame.maxX - size - margin,
+            y: screen.frame.maxY - size - margin - 30,  // below menu bar
+            width: size,
+            height: size
+        )
+
+        let window = NSWindow(contentRect: frame, styleMask: .borderless, backing: .buffered, defer: false)
+        window.isOpaque = false
+        window.backgroundColor = .clear
+        window.level = NSWindow.Level(Int(CGShieldingWindowLevel()) + 1)
+        window.ignoresMouseEvents = true
+        window.hasShadow = false
+
+        let hostView = NSHostingView(rootView: HandIndicatorView(isRewinding: true))
+        window.contentView = hostView
+        window.orderFront(nil)
+
+        indicatorWindow = window
+        indicatorView = hostView
+    }
+
+    private func hideHandIndicator() {
+        indicatorWindow?.orderOut(nil)
+        indicatorWindow = nil
+        indicatorView = nil
     }
 
     func updateContent(text: String, hasNextPage: Bool) {
@@ -385,6 +468,9 @@ class NotchOverlayController: NSObject {
         speechRecognizer.shouldDismiss = true
         speechRecognizer.forceStop()
         handGestureController.stop()
+        hideHandIndicator()
+        rewindTimer?.invalidate()
+        rewindTimer = nil
 
         // Wait for animation, then remove panel
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) { [weak self] in
@@ -424,6 +510,9 @@ class NotchOverlayController: NSObject {
         cancellables.removeAll()
         speechRecognizer.forceStop()
         handGestureController.stop()
+        hideHandIndicator()
+        rewindTimer?.invalidate()
+        rewindTimer = nil
         speechRecognizer.recognizedCharCount = 0
         panel?.orderOut(nil)
         panel = nil
@@ -609,6 +698,43 @@ struct DynamicIslandShape: Shape {
     }
 }
 
+// MARK: - Hand Gesture Indicator
+
+struct HandIndicatorView: View {
+    let isRewinding: Bool
+
+    @State private var rotation: Double = 0
+
+    var body: some View {
+        ZStack {
+            // Background circle
+            Circle()
+                .stroke(Color.white.opacity(0.3), lineWidth: 3)
+                .frame(width: 44, height: 44)
+
+            // Animated arc
+            Circle()
+                .trim(from: 0, to: 0.7)
+                .stroke(Color.green, style: StrokeStyle(lineWidth: 3, lineCap: .round))
+                .frame(width: 44, height: 44)
+                .rotationEffect(.degrees(rotation))
+
+            // Rewind icon
+            Image(systemName: "backward.fill")
+                .font(.system(size: 16, weight: .bold))
+                .foregroundColor(.green)
+        }
+        .frame(width: 60, height: 60)
+        .background(Color.black.opacity(0.6))
+        .clipShape(Circle())
+        .onAppear {
+            withAnimation(.linear(duration: 1).repeatForever(autoreverses: false)) {
+                rotation = -360
+            }
+        }
+    }
+}
+
 // MARK: - Overlay SwiftUI View
 
 struct NotchOverlayView: View {
@@ -638,8 +764,6 @@ struct NotchOverlayView: View {
     private let scrollTimer = Timer.publish(every: 0.05, on: .main, in: .common).autoconnect()
 
     // Hand-gesture rewind state
-    @State private var rewindTimer: Timer?
-    @State private var resumeDelay: DispatchWorkItem?
 
     // Auto next page countdown
     @State private var countdownRemaining: Int = 0
@@ -656,11 +780,6 @@ struct NotchOverlayView: View {
         NotchSettings.shared.listeningMode
     }
 
-    private func rewindWordsPerTick(handHeight: Float) -> Int {
-        if handHeight < 0.3 { return 1 }
-        if handHeight < 0.7 { return 2 }
-        return 4
-    }
 
     /// Convert fractional word index to char offset using actual word lengths
     private func charOffsetForWordProgress(_ progress: Double) -> Int {
@@ -817,55 +936,6 @@ struct NotchOverlayView: View {
         }
         .onChange(of: content.totalCharCount) { _, _ in
             timerWordProgress = 0
-        }
-        .onChange(of: handGesture.isHandRaised) { _, raised in
-            if raised {
-                resumeDelay?.cancel()
-                resumeDelay = nil
-
-                switch listeningMode {
-                case .wordTracking:
-                    speechRecognizer.pauseForRewind()
-                case .classic:
-                    isPaused = true
-                case .silencePaused:
-                    speechRecognizer.pauseForRewind()
-                    isPaused = true
-                }
-
-                rewindTimer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: true) { _ in
-                    let words = rewindWordsPerTick(handHeight: handGesture.handHeight)
-                    switch listeningMode {
-                    case .wordTracking:
-                        speechRecognizer.rewindByWords(words)
-                    case .classic, .silencePaused:
-                        timerWordProgress = max(0, timerWordProgress - Double(words))
-                    }
-                }
-            } else {
-                rewindTimer?.invalidate()
-                rewindTimer = nil
-
-                switch listeningMode {
-                case .wordTracking:
-                    speechRecognizer.resumeAfterRewind()
-                case .classic:
-                    let work = DispatchWorkItem { isPaused = false }
-                    resumeDelay = work
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: work)
-                case .silencePaused:
-                    speechRecognizer.resumeAfterRewind()
-                    let work = DispatchWorkItem { isPaused = false }
-                    resumeDelay = work
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: work)
-                }
-            }
-        }
-        .onDisappear {
-            rewindTimer?.invalidate()
-            rewindTimer = nil
-            resumeDelay?.cancel()
-            resumeDelay = nil
         }
     }
 
@@ -1226,18 +1296,11 @@ struct FloatingOverlayView: View {
     private let scrollTimer = Timer.publish(every: 0.05, on: .main, in: .common).autoconnect()
 
     // Hand-gesture rewind state
-    @State private var rewindTimer: Timer?
-    @State private var resumeDelay: DispatchWorkItem?
 
     private var listeningMode: ListeningMode {
         NotchSettings.shared.listeningMode
     }
 
-    private func rewindWordsPerTick(handHeight: Float) -> Int {
-        if handHeight < 0.3 { return 1 }
-        if handHeight < 0.7 { return 2 }
-        return 4
-    }
 
     /// Convert fractional word index to char offset using actual word lengths
     private func charOffsetForWordProgress(_ progress: Double) -> Int {
@@ -1371,55 +1434,6 @@ struct FloatingOverlayView: View {
         }
         .onChange(of: content.totalCharCount) { _, _ in
             timerWordProgress = 0
-        }
-        .onChange(of: handGesture.isHandRaised) { _, raised in
-            if raised {
-                resumeDelay?.cancel()
-                resumeDelay = nil
-
-                switch listeningMode {
-                case .wordTracking:
-                    speechRecognizer.pauseForRewind()
-                case .classic:
-                    isPaused = true
-                case .silencePaused:
-                    speechRecognizer.pauseForRewind()
-                    isPaused = true
-                }
-
-                rewindTimer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: true) { _ in
-                    let words = rewindWordsPerTick(handHeight: handGesture.handHeight)
-                    switch listeningMode {
-                    case .wordTracking:
-                        speechRecognizer.rewindByWords(words)
-                    case .classic, .silencePaused:
-                        timerWordProgress = max(0, timerWordProgress - Double(words))
-                    }
-                }
-            } else {
-                rewindTimer?.invalidate()
-                rewindTimer = nil
-
-                switch listeningMode {
-                case .wordTracking:
-                    speechRecognizer.resumeAfterRewind()
-                case .classic:
-                    let work = DispatchWorkItem { isPaused = false }
-                    resumeDelay = work
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: work)
-                case .silencePaused:
-                    speechRecognizer.resumeAfterRewind()
-                    let work = DispatchWorkItem { isPaused = false }
-                    resumeDelay = work
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: work)
-                }
-            }
-        }
-        .onDisappear {
-            rewindTimer?.invalidate()
-            rewindTimer = nil
-            resumeDelay?.cancel()
-            resumeDelay = nil
         }
     }
 

--- a/Textream/Textream/NotchSettings.swift
+++ b/Textream/Textream/NotchSettings.swift
@@ -407,6 +407,10 @@ class NotchSettings {
         didSet { UserDefaults.standard.set(selectedMicUID, forKey: "selectedMicUID") }
     }
 
+    var handGestureRewind: Bool {
+        didSet { UserDefaults.standard.set(handGestureRewind, forKey: "handGestureRewind") }
+    }
+
     var autoNextPage: Bool {
         didSet { UserDefaults.standard.set(autoNextPage, forKey: "autoNextPage") }
     }
@@ -483,6 +487,7 @@ class NotchSettings {
         self.hideFromScreenShare = UserDefaults.standard.object(forKey: "hideFromScreenShare") as? Bool ?? true
         self.showElapsedTime = UserDefaults.standard.object(forKey: "showElapsedTime") as? Bool ?? true
         self.selectedMicUID = UserDefaults.standard.string(forKey: "selectedMicUID") ?? ""
+        self.handGestureRewind = UserDefaults.standard.object(forKey: "handGestureRewind") as? Bool ?? true
         self.autoNextPage = UserDefaults.standard.object(forKey: "autoNextPage") as? Bool ?? false
         let savedDelay = UserDefaults.standard.integer(forKey: "autoNextPageDelay")
         self.autoNextPageDelay = savedDelay > 0 ? savedDelay : 3

--- a/Textream/Textream/NotchSettings.swift
+++ b/Textream/Textream/NotchSettings.swift
@@ -7,32 +7,6 @@
 
 import SwiftUI
 
-// MARK: - Font Size Preset
-
-enum FontSizePreset: String, CaseIterable, Identifiable {
-    case xs, sm, lg, xl
-
-    var id: String { rawValue }
-
-    var label: String {
-        switch self {
-        case .xs: return "XS"
-        case .sm: return "SM"
-        case .lg: return "LG"
-        case .xl: return "XL"
-        }
-    }
-
-    var pointSize: CGFloat {
-        switch self {
-        case .xs: return 14
-        case .sm: return 16
-        case .lg: return 20
-        case .xl: return 24
-        }
-    }
-}
-
 // MARK: - Font Family Preset
 
 enum FontFamilyPreset: String, CaseIterable, Identifiable {
@@ -161,6 +135,41 @@ enum CueBrightness: String, CaseIterable, Identifiable {
         case .low:    return 0.6
         case .medium: return 0.7
         case .bright: return 1.0
+        }
+    }
+}
+
+// MARK: - Browser Font Size Preset
+
+enum BrowserFontSizePreset: String, CaseIterable, Identifiable {
+    case sm, md, lg, xl
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .sm: return "SM"
+        case .md: return "MD"
+        case .lg: return "LG"
+        case .xl: return "XL"
+        }
+    }
+
+    var cssClamp: String {
+        switch self {
+        case .sm: return "clamp(24px,calc(100vw / 22),48px)"
+        case .md: return "clamp(32px,calc(100vw / 18),54px)"
+        case .lg: return "clamp(40px,calc(100vw / 14),60px)"
+        case .xl: return "clamp(48px,calc(100vw / 12),64px)"
+        }
+    }
+
+    var mobileCssClamp: String {
+        switch self {
+        case .sm: return "clamp(18px,calc(100vw / 16),36px)"
+        case .md: return "clamp(22px,calc(100vw / 13),42px)"
+        case .lg: return "clamp(28px,calc(100vw / 10),48px)"
+        case .xl: return "clamp(34px,calc(100vw / 8),56px)"
         }
     }
 }
@@ -319,19 +328,19 @@ enum ListeningMode: String, CaseIterable, Identifiable {
 class NotchSettings {
     static let shared = NotchSettings()
 
-    var notchWidth: CGFloat {
-        didSet { UserDefaults.standard.set(Double(notchWidth), forKey: "notchWidth") }
+    var windowWidthPercent: CGFloat {
+        didSet { UserDefaults.standard.set(Double(windowWidthPercent), forKey: "windowWidthPercent") }
     }
-    var textAreaHeight: CGFloat {
-        didSet { UserDefaults.standard.set(Double(textAreaHeight), forKey: "textAreaHeight") }
+    var windowHeightPercent: CGFloat {
+        didSet { UserDefaults.standard.set(Double(windowHeightPercent), forKey: "windowHeightPercent") }
     }
 
     var speechLocale: String {
         didSet { UserDefaults.standard.set(speechLocale, forKey: "speechLocale") }
     }
 
-    var fontSizePreset: FontSizePreset {
-        didSet { UserDefaults.standard.set(fontSizePreset.rawValue, forKey: "fontSizePreset") }
+    var fontSize: CGFloat {
+        didSet { UserDefaults.standard.set(Double(fontSize), forKey: "fontSize") }
     }
 
     var fontFamilyPreset: FontFamilyPreset {
@@ -419,6 +428,10 @@ class NotchSettings {
         didSet { UserDefaults.standard.set(Int(fullscreenScreenID), forKey: "fullscreenScreenID") }
     }
 
+    var fullscreenTopAnchor: Bool {
+        didSet { UserDefaults.standard.set(fullscreenTopAnchor, forKey: "fullscreenTopAnchor") }
+    }
+
     var browserServerEnabled: Bool {
         didSet {
             UserDefaults.standard.set(browserServerEnabled, forKey: "browserServerEnabled")
@@ -428,6 +441,10 @@ class NotchSettings {
 
     var browserServerPort: UInt16 {
         didSet { UserDefaults.standard.set(Int(browserServerPort), forKey: "browserServerPort") }
+    }
+
+    var browserFontSizePreset: BrowserFontSizePreset {
+        didSet { UserDefaults.standard.set(browserFontSizePreset.rawValue, forKey: "browserFontSizePreset") }
     }
 
     var directorModeEnabled: Bool {
@@ -442,25 +459,22 @@ class NotchSettings {
     }
 
     var font: NSFont {
-        fontFamilyPreset.font(size: fontSizePreset.pointSize)
+        fontFamilyPreset.font(size: fontSize)
     }
 
-    static let defaultWidth: CGFloat = 340
-    static let defaultHeight: CGFloat = 150
+    static let defaultWindowWidthPercent: CGFloat = 0.45
+    static let defaultWindowHeightPercent: CGFloat = 0.4
+    static let defaultFontSize: CGFloat = 20
     static let defaultLocale: String = Locale.current.identifier
 
-    static let minWidth: CGFloat = 310
-    static let maxWidth: CGFloat = 500
-    static let minHeight: CGFloat = 100
-    static let maxHeight: CGFloat = 400
-
     init() {
-        let savedWidth = UserDefaults.standard.double(forKey: "notchWidth")
-        let savedHeight = UserDefaults.standard.double(forKey: "textAreaHeight")
-        self.notchWidth = savedWidth > 0 ? CGFloat(savedWidth) : Self.defaultWidth
-        self.textAreaHeight = savedHeight > 0 ? CGFloat(savedHeight) : Self.defaultHeight
+        let savedWidthPercent = UserDefaults.standard.double(forKey: "windowWidthPercent")
+        self.windowWidthPercent = savedWidthPercent > 0 ? CGFloat(savedWidthPercent) : Self.defaultWindowWidthPercent
+        let savedHeightPercent = UserDefaults.standard.double(forKey: "windowHeightPercent")
+        self.windowHeightPercent = savedHeightPercent > 0 ? CGFloat(savedHeightPercent) : Self.defaultWindowHeightPercent
         self.speechLocale = UserDefaults.standard.string(forKey: "speechLocale") ?? Self.defaultLocale
-        self.fontSizePreset = FontSizePreset(rawValue: UserDefaults.standard.string(forKey: "fontSizePreset") ?? "") ?? .lg
+        let savedFontSize = UserDefaults.standard.double(forKey: "fontSize")
+        self.fontSize = savedFontSize > 0 ? CGFloat(savedFontSize) : Self.defaultFontSize
         self.fontFamilyPreset = FontFamilyPreset(rawValue: UserDefaults.standard.string(forKey: "fontFamilyPreset") ?? "") ?? .sans
         self.fontColorPreset = FontColorPreset(rawValue: UserDefaults.standard.string(forKey: "fontColorPreset") ?? "") ?? .white
         self.cueColorPreset = FontColorPreset(rawValue: UserDefaults.standard.string(forKey: "cueColorPreset") ?? "") ?? .white
@@ -488,9 +502,11 @@ class NotchSettings {
         self.autoNextPageDelay = savedDelay > 0 ? savedDelay : 3
         let savedFullscreenScreenID = UserDefaults.standard.integer(forKey: "fullscreenScreenID")
         self.fullscreenScreenID = UInt32(savedFullscreenScreenID)
+        self.fullscreenTopAnchor = UserDefaults.standard.object(forKey: "fullscreenTopAnchor") as? Bool ?? false
         self.browserServerEnabled = UserDefaults.standard.object(forKey: "browserServerEnabled") as? Bool ?? false
         let savedPort = UserDefaults.standard.integer(forKey: "browserServerPort")
         self.browserServerPort = savedPort > 0 ? UInt16(savedPort) : 7373
+        self.browserFontSizePreset = BrowserFontSizePreset(rawValue: UserDefaults.standard.string(forKey: "browserFontSizePreset") ?? "") ?? .lg
         self.directorModeEnabled = UserDefaults.standard.object(forKey: "directorModeEnabled") as? Bool ?? false
         let savedDirectorPort = UserDefaults.standard.integer(forKey: "directorServerPort")
         self.directorServerPort = savedDirectorPort > 0 ? UInt16(savedDirectorPort) : 7575

--- a/Textream/Textream/SettingsView.swift
+++ b/Textream/Textream/SettingsView.swift
@@ -743,6 +743,19 @@ struct SettingsView: View {
                 }
             }
 
+            Divider()
+
+            Toggle(isOn: $settings.handGestureRewind) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Hand Gesture Rewind")
+                        .font(.system(size: 13, weight: .medium))
+                    Text("Raise your hand to pause and rewind. The higher you raise, the faster it rewinds. Lower your hand to resume. Uses your camera to detect hand position.")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .toggleStyle(.checkbox)
+
             Spacer()
         }
         .padding(16)

--- a/Textream/Textream/SettingsView.swift
+++ b/Textream/Textream/SettingsView.swift
@@ -23,7 +23,7 @@ class NotchPreviewController {
     func show(settings: NotchSettings) {
         // If panel already exists, just re-show it
         if let panel {
-            panel.orderFront(nil)
+            panel.orderFrontRegardless()
             return
         }
 
@@ -32,10 +32,10 @@ class NotchPreviewController {
         let visibleFrame = screen.visibleFrame
         let menuBarHeight = screenFrame.maxY - visibleFrame.maxY
 
-        let maxWidth = NotchSettings.maxWidth
-        let maxHeight = menuBarHeight + NotchSettings.maxHeight + 40
+        let previewWidth = screenFrame.width * 0.8
+        let maxHeight = menuBarHeight + screenFrame.height * 0.5 + 40
 
-        let xPosition = screenFrame.midX - maxWidth / 2
+        let xPosition = screenFrame.midX - previewWidth / 2
         let yPosition = screenFrame.maxY - maxHeight
 
         let content = NotchPreviewContent(settings: settings, menuBarHeight: menuBarHeight)
@@ -43,7 +43,7 @@ class NotchPreviewController {
         self.hostingView = hostingView
 
         let panel = NSPanel(
-            contentRect: NSRect(x: xPosition, y: yPosition, width: maxWidth, height: maxHeight),
+            contentRect: NSRect(x: xPosition, y: yPosition, width: previewWidth, height: maxHeight),
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
             defer: false
@@ -53,8 +53,9 @@ class NotchPreviewController {
         panel.hasShadow = false
         panel.level = .statusBar
         panel.ignoresMouseEvents = true
+        panel.hidesOnDeactivate = false
         panel.contentView = hostingView
-        panel.orderFront(nil)
+        panel.orderFrontRegardless()
         self.panel = panel
     }
 
@@ -105,13 +106,13 @@ class NotchPreviewController {
     private func cursorFrame(for panel: NSPanel, settings: NotchSettings) -> NSRect {
         let mouse = NSEvent.mouseLocation
         let cursorOffset: CGFloat = 8
-        let maxWidth = panel.frame.width
-        let notchWidth = settings.notchWidth
+        let screenWidth = NSScreen.main?.frame.width ?? 1440
+        let notchWidth = screenWidth * settings.windowWidthPercent
         let panelHeight = panel.frame.height
 
-        let panelX = mouse.x + cursorOffset - (maxWidth - notchWidth) / 2
+        let panelX = mouse.x + cursorOffset
         let panelY = mouse.y + 60 - panelHeight
-        return NSRect(x: panelX, y: panelY, width: maxWidth, height: panelHeight)
+        return NSRect(x: panelX, y: panelY, width: notchWidth, height: panelHeight)
     }
 
     private func startCursorTracking() {
@@ -153,8 +154,10 @@ struct NotchPreviewContent: View {
     var body: some View {
         GeometryReader { geo in
             let topPadding = menuBarHeight * (1 - offsetPhase) + 14 * offsetPhase
-            let contentHeight = topPadding + settings.textAreaHeight
-            let currentWidth = settings.notchWidth
+            let screenHeight = NSScreen.main?.frame.height ?? 900
+            let contentHeight = topPadding + screenHeight * settings.windowHeightPercent
+            let screenWidth = NSScreen.main?.frame.width ?? 1440
+            let currentWidth = min(screenWidth * settings.windowWidthPercent, geo.size.width)
             let yOffset = 60 * offsetPhase
 
             ZStack(alignment: .top) {
@@ -214,8 +217,8 @@ struct NotchPreviewContent: View {
             .frame(width: currentWidth, height: contentHeight, alignment: .top)
             .offset(y: yOffset)
             .frame(width: geo.size.width, height: geo.size.height, alignment: .top)
-            .animation(.easeInOut(duration: 0.15), value: settings.notchWidth)
-            .animation(.easeInOut(duration: 0.15), value: settings.textAreaHeight)
+            .animation(.easeInOut(duration: 0.15), value: settings.windowWidthPercent)
+            .animation(.easeInOut(duration: 0.15), value: settings.windowHeightPercent)
         }
         .onChange(of: settings.overlayMode) { _, mode in
             if mode == .floating {
@@ -305,7 +308,7 @@ struct SettingsView: View {
     var body: some View {
         HStack(spacing: 0) {
             // Sidebar
-            VStack(alignment: .leading, spacing: 2) {
+            VStack(alignment: .leading, spacing: 0) {
                 Text("Settings")
                     .font(.system(size: 11, weight: .semibold))
                     .foregroundStyle(.tertiary)
@@ -314,24 +317,23 @@ struct SettingsView: View {
                     .padding(.bottom, 6)
 
                 ForEach(SettingsTab.allCases) { tab in
-                    Button {
-                        selectedTab = tab
-                    } label: {
-                        HStack(spacing: 7) {
-                            Image(systemName: tab.icon)
-                                .font(.system(size: 12, weight: .medium))
-                                .frame(width: 16)
-                            Text(tab.label)
-                                .font(.system(size: 13, weight: .regular))
-                        }
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 7)
-                        .background(selectedTab == tab ? Color.accentColor.opacity(0.15) : Color.clear)
-                        .foregroundStyle(selectedTab == tab ? Color.accentColor : .primary)
-                        .clipShape(RoundedRectangle(cornerRadius: 6))
+                    HStack(spacing: 7) {
+                        Image(systemName: tab.icon)
+                            .font(.system(size: 12, weight: .medium))
+                            .frame(width: 16)
+                        Text(tab.label)
+                            .font(.system(size: 13, weight: .regular))
                     }
-                    .buttonStyle(.plain)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 7)
+                    .background(selectedTab == tab ? Color.accentColor.opacity(0.15) : Color.clear)
+                    .foregroundStyle(selectedTab == tab ? Color.accentColor : .primary)
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        selectedTab = tab
+                    }
                 }
 
                 Spacer()
@@ -383,8 +385,7 @@ struct SettingsView: View {
             }
             .frame(maxWidth: .infinity)
         }
-        .frame(width: 500)
-        .frame(minHeight: 280, maxHeight: 500)
+        .frame(width: 500, height: 500)
         .background(.ultraThinMaterial)
         .alert("Reset All Settings?", isPresented: $showResetConfirmation) {
             Button("Cancel", role: .cancel) { }
@@ -396,50 +397,22 @@ struct SettingsView: View {
         } message: {
             Text("This will restore all settings to their defaults.")
         }
-        .onAppear {
-            if settings.overlayMode != .fullscreen {
+        .onChange(of: selectedTab) { _, tab in
+            if tab == .teleprompter && settings.overlayMode != .fullscreen {
                 previewController.show(settings: settings)
-                if settings.followCursorWhenUndocked && settings.overlayMode == .floating {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                        previewController.animateToCursor(settings: settings)
-                    }
-                }
+            } else {
+                previewController.hide()
+            }
+        }
+        .onChange(of: settings.overlayMode) { _, mode in
+            if selectedTab == .teleprompter && mode != .fullscreen {
+                previewController.show(settings: settings)
+            } else {
+                previewController.hide()
             }
         }
         .onDisappear {
             previewController.dismiss()
-        }
-        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didResignActiveNotification)) { _ in
-            previewController.hide()
-        }
-        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
-            if settings.overlayMode != .fullscreen {
-                previewController.show(settings: settings)
-                if settings.followCursorWhenUndocked && settings.overlayMode == .floating {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                        previewController.animateToCursor(settings: settings)
-                    }
-                }
-            }
-        }
-        .onChange(of: settings.followCursorWhenUndocked) { _, follow in
-            if follow && settings.overlayMode == .floating {
-                previewController.animateToCursor(settings: settings)
-            } else {
-                previewController.animateFromCursor()
-            }
-        }
-        .onChange(of: settings.overlayMode) { _, mode in
-            if mode == .fullscreen {
-                previewController.hide()
-            } else {
-                previewController.show(settings: settings)
-                if mode == .floating && settings.followCursorWhenUndocked {
-                    previewController.animateToCursor(settings: settings)
-                } else if previewController.isAtCursor {
-                    previewController.animateFromCursor()
-                }
-            }
         }
     }
 
@@ -482,39 +455,29 @@ struct SettingsView: View {
                     }
                 }
 
-                // Text Size
-                Text("Size")
-                    .font(.system(size: 13, weight: .medium))
-
-                HStack(spacing: 8) {
-                    ForEach(FontSizePreset.allCases) { preset in
-                        Button {
-                            withAnimation(.easeInOut(duration: 0.2)) {
-                                settings.fontSizePreset = preset
-                            }
-                        } label: {
-                            VStack(spacing: 6) {
-                                Text("Ag")
-                                    .font(Font(settings.fontFamilyPreset.font(size: preset.pointSize * 0.7)))
-                                    .foregroundStyle(settings.fontSizePreset == preset ? Color.accentColor : .primary)
-                                Text(preset.label)
-                                    .font(.system(size: 11, weight: .medium))
-                                    .foregroundStyle(settings.fontSizePreset == preset ? Color.accentColor : .secondary)
-                            }
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, 12)
-                            .background(
-                                RoundedRectangle(cornerRadius: 10)
-                                    .fill(settings.fontSizePreset == preset ? Color.accentColor.opacity(0.12) : Color.primary.opacity(0.05))
-                            )
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 10)
-                                    .strokeBorder(settings.fontSizePreset == preset ? Color.accentColor.opacity(0.4) : Color.clear, lineWidth: 1.5)
-                            )
-                        }
-                        .buttonStyle(.plain)
+                // Font Size
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack {
+                        Text("Font Size")
+                            .font(.system(size: 12))
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Text("\(Int(settings.fontSize))pt")
+                            .font(.system(size: 11, weight: .regular, design: .monospaced))
+                            .foregroundStyle(.tertiary)
                     }
+                    Slider(
+                        value: $settings.fontSize,
+                        in: 14...100,
+                        step: 8
+                    )
                 }
+
+                Text("Ag")
+                    .font(Font(settings.fontFamilyPreset.font(size: min(settings.fontSize, 48))))
+                    .foregroundStyle(.primary)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.vertical, 4)
 
                 Divider()
 
@@ -620,47 +583,6 @@ struct SettingsView: View {
                 .pickerStyle(.segmented)
                 .labelsHidden()
 
-                Divider()
-
-                // Dimensions
-                Text("Dimensions")
-                    .font(.system(size: 13, weight: .medium))
-
-                VStack(spacing: 10) {
-                    VStack(alignment: .leading, spacing: 4) {
-                        HStack {
-                            Text("Width")
-                                .font(.system(size: 12))
-                                .foregroundStyle(.secondary)
-                            Spacer()
-                            Text("\(Int(settings.notchWidth))px")
-                                .font(.system(size: 11, weight: .regular, design: .monospaced))
-                                .foregroundStyle(.tertiary)
-                        }
-                        Slider(
-                            value: $settings.notchWidth,
-                            in: NotchSettings.minWidth...NotchSettings.maxWidth,
-                            step: 10
-                        )
-                    }
-
-                    VStack(alignment: .leading, spacing: 4) {
-                        HStack {
-                            Text("Height")
-                                .font(.system(size: 12))
-                                .foregroundStyle(.secondary)
-                            Spacer()
-                            Text("\(Int(settings.textAreaHeight))px")
-                                .font(.system(size: 11, weight: .regular, design: .monospaced))
-                                .foregroundStyle(.tertiary)
-                        }
-                        Slider(
-                            value: $settings.textAreaHeight,
-                            in: NotchSettings.minHeight...NotchSettings.maxHeight,
-                            step: 10
-                        )
-                    }
-                }
             }
             .padding(16)
         }
@@ -771,7 +693,7 @@ struct SettingsView: View {
                     .font(.system(size: 11))
                     .foregroundStyle(.secondary)
 
-                if settings.overlayMode == .pinned {
+                if settings.overlayMode == .floating {
                     Divider()
 
                     Text("Display")
@@ -796,9 +718,7 @@ struct SettingsView: View {
                             onRefresh: { refreshOverlayScreens() }
                         )
                     }
-                }
 
-                if settings.overlayMode == .floating {
                     Divider()
 
                     Toggle(isOn: $settings.followCursorWhenUndocked) {
@@ -867,9 +787,64 @@ struct SettingsView: View {
                         RoundedRectangle(cornerRadius: 8)
                             .fill(Color.primary.opacity(0.04))
                     )
+
+                    Toggle(isOn: $settings.fullscreenTopAnchor) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Lock Text to Top")
+                                .font(.system(size: 13, weight: .medium))
+                            Text("Anchor the current line near the top of the screen instead of the center.")
+                                .font(.system(size: 11))
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .toggleStyle(.checkbox)
                 }
 
-                Divider()
+                if settings.overlayMode != .fullscreen {
+                    Divider()
+
+                    // Dimensions
+                    Text("Dimensions")
+                        .font(.system(size: 13, weight: .medium))
+
+                    VStack(spacing: 10) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            HStack {
+                                Text("Width")
+                                    .font(.system(size: 12))
+                                    .foregroundStyle(.secondary)
+                                Spacer()
+                                Text("\(Int(settings.windowWidthPercent * 100))%")
+                                    .font(.system(size: 11, weight: .regular, design: .monospaced))
+                                    .foregroundStyle(.tertiary)
+                            }
+                            Slider(
+                                value: $settings.windowWidthPercent,
+                                in: 0.2...0.8,
+                                step: 0.05
+                            )
+                        }
+
+                        VStack(alignment: .leading, spacing: 4) {
+                            HStack {
+                                Text("Height")
+                                    .font(.system(size: 12))
+                                    .foregroundStyle(.secondary)
+                                Spacer()
+                                Text("\(Int(settings.windowHeightPercent * 100))%")
+                                    .font(.system(size: 11, weight: .regular, design: .monospaced))
+                                    .foregroundStyle(.tertiary)
+                            }
+                            Slider(
+                                value: $settings.windowHeightPercent,
+                                in: 0.05...0.5,
+                                step: 0.05
+                            )
+                        }
+                    }
+
+                    Divider()
+                }
 
                 // Options
                 Toggle(isOn: $settings.showElapsedTime) {
@@ -983,6 +958,17 @@ struct SettingsView: View {
                     onRefresh: { refreshScreens() },
                     emptyMessage: "No external displays detected. Connect a display or enable Sidecar."
                 )
+
+                Toggle(isOn: $settings.fullscreenTopAnchor) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Lock Text to Top")
+                            .font(.system(size: 13, weight: .medium))
+                        Text("Anchor the current line near the top of the screen instead of the center.")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .toggleStyle(.checkbox)
             }
             Spacer()
         }
@@ -1049,6 +1035,18 @@ struct SettingsView: View {
                     RoundedRectangle(cornerRadius: 8)
                         .fill(Color.accentColor.opacity(0.08))
                 )
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Remote Text Size")
+                        .font(.system(size: 13, weight: .medium))
+                    Picker("", selection: $settings.browserFontSizePreset) {
+                        ForEach(BrowserFontSizePreset.allCases) { preset in
+                            Text(preset.label).tag(preset)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    .labelsHidden()
+                }
 
                 DisclosureGroup("Advanced", isExpanded: $showAdvanced) {
                     VStack(alignment: .leading, spacing: 10) {
@@ -1316,9 +1314,9 @@ struct SettingsView: View {
     // MARK: - Helpers
 
     private func resetAllSettings() {
-        settings.notchWidth = NotchSettings.defaultWidth
-        settings.textAreaHeight = NotchSettings.defaultHeight
-        settings.fontSizePreset = .lg
+        settings.windowWidthPercent = NotchSettings.defaultWindowWidthPercent
+        settings.windowHeightPercent = NotchSettings.defaultWindowHeightPercent
+        settings.fontSize = NotchSettings.defaultFontSize
         settings.fontFamilyPreset = .sans
         settings.fontColorPreset = .white
         settings.cueColorPreset = .white
@@ -1330,6 +1328,7 @@ struct SettingsView: View {
         settings.glassOpacity = 0.15
         settings.followCursorWhenUndocked = false
         settings.fullscreenScreenID = 0
+        settings.fullscreenTopAnchor = false
         settings.externalDisplayMode = .off
         settings.externalScreenID = 0
         settings.mirrorAxis = .horizontal
@@ -1341,6 +1340,7 @@ struct SettingsView: View {
         settings.autoNextPageDelay = 3
         settings.browserServerEnabled = false
         settings.browserServerPort = 7373
+        settings.browserFontSizePreset = .lg
         settings.directorModeEnabled = false
         settings.directorServerPort = 7575
     }

--- a/Textream/Textream/SpeechRecognizer.swift
+++ b/Textream/Textream/SpeechRecognizer.swift
@@ -240,6 +240,7 @@ class SpeechRecognizer {
     func resumeAfterRewind() {
         matchStartOffset = recognizedCharCount
         retryCount = 0
+        isListening = true
         beginRecognition()
     }
 

--- a/Textream/Textream/SpeechRecognizer.swift
+++ b/Textream/Textream/SpeechRecognizer.swift
@@ -209,6 +209,40 @@ class SpeechRecognizer {
         beginRecognition()
     }
 
+    /// Pause speech recognition for gesture rewind without changing isListening state.
+    func pauseForRewind() {
+        cleanupRecognition()
+    }
+
+    /// Move recognizedCharCount backward by N words. Used during gesture rewind.
+    func rewindByWords(_ count: Int) {
+        let chars = Array(sourceText)
+        var remaining = count
+        var offset = recognizedCharCount
+
+        while remaining > 0 && offset > 0 {
+            // Skip any spaces at current position
+            while offset > 0 && chars[offset - 1] == " " {
+                offset -= 1
+            }
+            // Skip to start of current word
+            while offset > 0 && chars[offset - 1] != " " {
+                offset -= 1
+            }
+            remaining -= 1
+        }
+
+        recognizedCharCount = max(0, offset)
+        matchStartOffset = recognizedCharCount
+    }
+
+    /// Resume speech recognition after gesture rewind from current position.
+    func resumeAfterRewind() {
+        matchStartOffset = recognizedCharCount
+        retryCount = 0
+        beginRecognition()
+    }
+
     private func cleanupRecognition() {
         // Cancel any pending restart to prevent overlapping beginRecognition calls
         pendingRestart?.cancel()

--- a/Textream/Textream/SpeechRecognizer.swift
+++ b/Textream/Textream/SpeechRecognizer.swift
@@ -209,6 +209,42 @@ class SpeechRecognizer {
         beginRecognition()
     }
 
+    /// Pause speech recognition for gesture rewind without changing isListening state.
+    func pauseForRewind() {
+        cleanupRecognition()
+    }
+
+    /// Move recognizedCharCount backward by N words. Used during gesture rewind.
+    func rewindByWords(_ count: Int) {
+        let chars = Array(sourceText)
+        guard !chars.isEmpty else { return }
+        var remaining = count
+        var offset = min(recognizedCharCount, chars.count)
+
+        while remaining > 0 && offset > 0 {
+            // Skip any spaces at current position
+            while offset > 0 && chars[offset - 1] == " " {
+                offset -= 1
+            }
+            // Skip to start of current word
+            while offset > 0 && chars[offset - 1] != " " {
+                offset -= 1
+            }
+            remaining -= 1
+        }
+
+        recognizedCharCount = max(0, offset)
+        matchStartOffset = recognizedCharCount
+    }
+
+    /// Resume speech recognition after gesture rewind from current position.
+    func resumeAfterRewind() {
+        matchStartOffset = recognizedCharCount
+        retryCount = 0
+        isListening = true
+        beginRecognition()
+    }
+
     private func cleanupRecognition() {
         // Cancel any pending restart to prevent overlapping beginRecognition calls
         pendingRestart?.cancel()

--- a/Textream/Textream/Textream.entitlements
+++ b/Textream/Textream/Textream.entitlements
@@ -6,6 +6,8 @@
 	<true/>
 	<key>com.apple.security.device.audio-input</key>
 	<true/>
+	<key>com.apple.security.device.camera</key>
+	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
 	<key>com.apple.security.network.client</key>

--- a/Textream/Textream/TextreamService.swift
+++ b/Textream/Textream/TextreamService.swift
@@ -163,6 +163,7 @@ class TextreamService: NSObject, ObservableObject {
 
     @Published var currentFileURL: URL?
     @Published var savedPages: [String] = [""]
+    @Published var documentTitle: String = "Untitled"
 
     // MARK: - File Operations
 
@@ -177,7 +178,8 @@ class TextreamService: NSObject, ObservableObject {
     func saveFileAs() {
         let panel = NSSavePanel()
         panel.allowedContentTypes = [.init(filenameExtension: "textream")!]
-        panel.nameFieldStringValue = "Untitled.textream"
+        let title = documentTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        panel.nameFieldStringValue = (title.isEmpty ? "Untitled" : title) + ".textream"
         panel.canCreateDirectories = true
 
         panel.begin { [weak self] response in

--- a/docs/superpowers/plans/2026-03-22-hand-gesture-rewind.md
+++ b/docs/superpowers/plans/2026-03-22-hand-gesture-rewind.md
@@ -1,0 +1,501 @@
+# Hand Gesture Rewind Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add hands-free script rewind via raised hand detection using the Mac's front-facing camera and Apple Vision framework.
+
+**Architecture:** A new `HandGestureController` owns camera capture and Vision hand pose detection, publishing `isHandRaised` and `handHeight`. The overlay views observe these values and dispatch rewind to the appropriate scroll state (`recognizedCharCount` for wordTracking, `timerWordProgress` for classic/silencePaused). New methods on `SpeechRecognizer` handle pause/rewind/resume for wordTracking mode.
+
+**Tech Stack:** Swift, AVFoundation (camera capture), Vision framework (VNDetectHumanHandPoseRequest)
+
+**Spec:** `docs/superpowers/specs/2026-03-22-hand-gesture-rewind-design.md`
+
+**Note:** This project has no test target. All Swift files live in `Textream/Textream/`. The project builds via `xcodebuild` from `Textream/Textream.xcodeproj`. Use `CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""` when building.
+
+**Important — Adding files to Xcode project:** This is a pure Xcode project (no SPM). New `.swift` files are auto-discovered by the build system. Bundle resources and entitlements changes need manual verification.
+
+---
+
+## File Map
+
+### New Files
+
+| File | Responsibility |
+|------|---------------|
+| `Textream/Textream/HandGestureController.swift` | AVCaptureSession setup, VNDetectHumanHandPoseRequest processing, wrist Y smoothing, publishes `isHandRaised` and `handHeight` |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `Textream/Textream/SpeechRecognizer.swift` | Add `pauseForRewind()`, `rewindByWords(_:)`, `resumeAfterRewind()` methods |
+| `Textream/Textream/NotchOverlayController.swift` | Create `HandGestureController`, observe hand state in both overlay views, manage rewind timer, dispatch to correct scroll state per mode |
+| `Textream/Info.plist` | Add `NSCameraUsageDescription` |
+| `Textream/Textream/Textream.entitlements` | Add `com.apple.security.device.camera` |
+
+---
+
+### Task 1: Camera Permission and Entitlements
+
+**Files:**
+- Modify: `Textream/Info.plist`
+- Modify: `Textream/Textream/Textream.entitlements`
+
+- [ ] **Step 1: Add camera usage description to Info.plist**
+
+Add the following key/value pair inside the `<dict>` in `Textream/Info.plist`, after the existing `NSServices` block:
+
+```xml
+<key>NSCameraUsageDescription</key>
+<string>Textream uses the camera to detect hand gestures for hands-free script control.</string>
+```
+
+- [ ] **Step 2: Add camera entitlement**
+
+Add the following key/value pair inside the `<dict>` in `Textream/Textream/Textream.entitlements`, after the existing `com.apple.security.device.audio-input` entry:
+
+```xml
+<key>com.apple.security.device.camera</key>
+<true/>
+```
+
+- [ ] **Step 3: Verify build**
+
+```bash
+cd Textream && xcodebuild -scheme Textream -configuration Debug CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" build 2>&1 | tail -5
+```
+
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Textream/Info.plist Textream/Textream/Textream.entitlements
+git commit -m "feat: add camera permission and entitlement for hand gesture rewind"
+```
+
+---
+
+### Task 2: HandGestureController
+
+**Files:**
+- Create: `Textream/Textream/HandGestureController.swift`
+
+This is the core camera + Vision processing class. It owns the capture session, runs hand pose detection on each frame, smooths the wrist position, and publishes state.
+
+- [ ] **Step 1: Implement HandGestureController**
+
+```swift
+import AVFoundation
+import Vision
+import AppKit
+
+@Observable
+class HandGestureController: NSObject {
+    var isHandRaised: Bool = false
+    var handHeight: Float = 0.0  // 0.0 = just above threshold, 1.0 = top of frame
+
+    private var captureSession: AVCaptureSession?
+    private let videoOutput = AVCaptureVideoDataOutput()
+    private let processingQueue = DispatchQueue(label: "com.textream.handgesture", qos: .userInteractive)
+    private let handPoseRequest = VNDetectHumanHandPoseRequest()
+
+    private let raiseThreshold: Float = 0.6  // wrist Y must exceed this to count as raised
+    private var recentWristY: [Float] = []   // rolling buffer for smoothing
+    private let smoothingWindow = 4
+
+    private var isRunning = false
+
+    override init() {
+        super.init()
+        handPoseRequest.maximumHandCount = 2
+    }
+
+    func start() {
+        guard !isRunning else { return }
+
+        // Check camera permission
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        case .authorized:
+            setupAndStart()
+        case .notDetermined:
+            AVCaptureDevice.requestAccess(for: .video) { [weak self] granted in
+                if granted {
+                    DispatchQueue.main.async { self?.setupAndStart() }
+                }
+            }
+        default:
+            // Permission denied or restricted — silently disable
+            return
+        }
+    }
+
+    func stop() {
+        guard isRunning else { return }
+        captureSession?.stopRunning()
+        isRunning = false
+        isHandRaised = false
+        handHeight = 0.0
+        recentWristY = []
+    }
+
+    private func setupAndStart() {
+        let session = AVCaptureSession()
+        session.sessionPreset = .low  // ~640x480, minimal resource usage
+
+        // Find front-facing camera
+        guard let camera = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: .front)
+                ?? AVCaptureDevice.default(for: .video) else {
+            // No camera available — silently disable
+            return
+        }
+
+        guard let input = try? AVCaptureDeviceInput(device: camera) else { return }
+        guard session.canAddInput(input) else { return }
+        session.addInput(input)
+
+        videoOutput.setSampleBufferDelegate(self, queue: processingQueue)
+        videoOutput.alwaysDiscardsLateVideoFrames = true
+        guard session.canAddOutput(videoOutput) else { return }
+        session.addOutput(videoOutput)
+
+        // Limit frame rate to ~15fps to save CPU
+        if let connection = videoOutput.connection(with: .video) {
+            connection.isEnabled = true
+        }
+        try? camera.lockForConfiguration()
+        camera.activeVideoMinFrameDuration = CMTime(value: 1, timescale: 15)
+        camera.activeVideoMaxFrameDuration = CMTime(value: 1, timescale: 15)
+        camera.unlockForConfiguration()
+
+        captureSession = session
+
+        processingQueue.async {
+            session.startRunning()
+        }
+        isRunning = true
+    }
+}
+
+extension HandGestureController: AVCaptureVideoDataOutputSampleBufferDelegate {
+    func captureOutput(_ output: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection) {
+        guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
+
+        let handler = VNImageRequestHandler(cvPixelBuffer: pixelBuffer, orientation: .up, options: [:])
+        try? handler.perform([handPoseRequest])
+
+        guard let results = handPoseRequest.results, !results.isEmpty else {
+            DispatchQueue.main.async {
+                self.updateWristPosition(nil)
+            }
+            return
+        }
+
+        // Find the hand with the highest wrist Y
+        var highestWristY: Float = 0
+        for hand in results {
+            if let wrist = try? hand.recognizedPoint(.wrist),
+               wrist.confidence > 0.3 {
+                let y = Float(wrist.location.y)  // Vision coords: 0=bottom, 1=top
+                if y > highestWristY {
+                    highestWristY = y
+                }
+            }
+        }
+
+        DispatchQueue.main.async {
+            self.updateWristPosition(highestWristY > 0 ? highestWristY : nil)
+        }
+    }
+
+    private func updateWristPosition(_ wristY: Float?) {
+        guard let y = wristY else {
+            // No hand detected — decay smoothly
+            recentWristY = []
+            isHandRaised = false
+            handHeight = 0.0
+            return
+        }
+
+        // Smooth with rolling average
+        recentWristY.append(y)
+        if recentWristY.count > smoothingWindow {
+            recentWristY.removeFirst()
+        }
+        let smoothed = recentWristY.reduce(0, +) / Float(recentWristY.count)
+
+        if smoothed > raiseThreshold {
+            isHandRaised = true
+            // Map threshold..1.0 → 0.0..1.0
+            handHeight = min(1.0, (smoothed - raiseThreshold) / (1.0 - raiseThreshold))
+        } else {
+            isHandRaised = false
+            handHeight = 0.0
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+```bash
+cd Textream && xcodebuild -scheme Textream -configuration Debug CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" build 2>&1 | tail -5
+```
+
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Textream/Textream/HandGestureController.swift
+git commit -m "feat: add HandGestureController with Vision hand pose detection"
+```
+
+---
+
+### Task 3: SpeechRecognizer Rewind Methods
+
+**Files:**
+- Modify: `Textream/Textream/SpeechRecognizer.swift`
+
+Add three new public methods that the overlay views will call during hand gesture rewind. These methods encapsulate access to the private `matchStartOffset`, `sourceText`, `cleanupRecognition()`, and `beginRecognition()`.
+
+- [ ] **Step 1: Add pauseForRewind()**
+
+Add the following method after `resume()` (after line 210 in SpeechRecognizer.swift):
+
+```swift
+    /// Pause speech recognition for gesture rewind without changing isListening state.
+    func pauseForRewind() {
+        cleanupRecognition()
+    }
+```
+
+- [ ] **Step 2: Add rewindByWords(\_:)**
+
+Add directly after `pauseForRewind()`:
+
+```swift
+    /// Move recognizedCharCount backward by N words. Used during gesture rewind.
+    func rewindByWords(_ count: Int) {
+        // Work with the string as an array for O(1) indexing
+        let chars = Array(sourceText)
+        var remaining = count
+        var offset = recognizedCharCount
+
+        while remaining > 0 && offset > 0 {
+            // Skip any spaces at current position
+            while offset > 0 && chars[offset - 1] == " " {
+                offset -= 1
+            }
+            // Skip to start of current word
+            while offset > 0 && chars[offset - 1] != " " {
+                offset -= 1
+            }
+            remaining -= 1
+        }
+
+        recognizedCharCount = max(0, offset)
+        matchStartOffset = recognizedCharCount
+    }
+```
+
+- [ ] **Step 3: Add resumeAfterRewind()**
+
+Add directly after `rewindByWords(_:)`:
+
+```swift
+    /// Resume speech recognition after gesture rewind from current position.
+    func resumeAfterRewind() {
+        matchStartOffset = recognizedCharCount
+        retryCount = 0
+        beginRecognition()
+    }
+```
+
+- [ ] **Step 4: Verify build**
+
+```bash
+cd Textream && xcodebuild -scheme Textream -configuration Debug CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" build 2>&1 | tail -5
+```
+
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Textream/Textream/SpeechRecognizer.swift
+git commit -m "feat: add pauseForRewind, rewindByWords, resumeAfterRewind to SpeechRecognizer"
+```
+
+---
+
+### Task 4: Integrate HandGestureController into Overlay Views
+
+**Files:**
+- Modify: `Textream/Textream/NotchOverlayController.swift`
+
+This is the integration task. The `HandGestureController` needs to be:
+1. Created and owned by `NotchOverlayController`
+2. Started/stopped with reading sessions
+3. Observed by both `NotchOverlayView` and `FloatingOverlayView` to drive rewind
+
+**Key context:** `timerWordProgress` is `@State private` on both `NotchOverlayView` (line 625) and `FloatingOverlayView` (line 1153). The rewind logic for classic/silencePaused must live inside these views since they own the state. The `HandGestureController` is passed to both views and observed via `onChange(of:)`.
+
+- [ ] **Step 1: Add HandGestureController to NotchOverlayController**
+
+In the `NotchOverlayController` class (around line 47), add a property:
+
+```swift
+let handGestureController = HandGestureController()
+```
+
+- [ ] **Step 2: Start/stop camera with reading sessions**
+
+Find `show(text:hasNextPage:onComplete:)` (line 62) — after the existing `speechRecognizer.start(with:)` call (line 118), add:
+
+```swift
+handGestureController.start()
+```
+
+Find `updateContent(text:hasNextPage:)` (line 122) — similarly add `handGestureController.start()` after the recognizer start.
+
+Find `dismiss()` (line 376) and `forceClose()` (line 411) — add to both:
+
+```swift
+handGestureController.stop()
+```
+
+- [ ] **Step 3: Pass HandGestureController to NotchOverlayView**
+
+The `NotchOverlayView` needs access to `handGestureController`. Add it as a parameter to the view's init. Find where `NotchOverlayView` is created in `NotchOverlayController` and pass `handGestureController`.
+
+In `NotchOverlayView`, add a property:
+
+```swift
+var handGesture: HandGestureController
+```
+
+- [ ] **Step 4: Add rewind logic to NotchOverlayView**
+
+Add a rewind timer state and handler to `NotchOverlayView`. Add these properties near the other `@State` declarations (around line 625):
+
+```swift
+@State private var rewindTimer: Timer?
+@State private var resumeDelay: DispatchWorkItem?
+```
+
+Add a helper to compute words-per-tick from hand height:
+
+```swift
+private func rewindWordsPerTick(handHeight: Float) -> Int {
+    if handHeight < 0.3 { return 1 }
+    if handHeight < 0.7 { return 2 }
+    return 4
+}
+```
+
+Add `onChange` handlers in the view body (inside the main container, near the existing `onChange` handlers):
+
+```swift
+.onChange(of: handGesture.isHandRaised) { _, raised in
+    if raised {
+        // Cancel any pending resume delay
+        resumeDelay?.cancel()
+        resumeDelay = nil
+
+        // Pause current mode
+        switch listeningMode {
+        case .wordTracking:
+            speechRecognizer.pauseForRewind()
+        case .classic:
+            isPaused = true
+        case .silencePaused:
+            speechRecognizer.pauseForRewind()
+            isPaused = true  // also pause the scroll timer
+        }
+
+        // Start rewind timer
+        rewindTimer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: true) { _ in
+            let words = rewindWordsPerTick(handHeight: handGesture.handHeight)
+            switch listeningMode {
+            case .wordTracking:
+                speechRecognizer.rewindByWords(words)
+            case .classic, .silencePaused:
+                timerWordProgress = max(0, timerWordProgress - Double(words))
+            }
+        }
+    } else {
+        // Stop rewind timer
+        rewindTimer?.invalidate()
+        rewindTimer = nil
+
+        // Resume based on mode
+        switch listeningMode {
+        case .wordTracking:
+            speechRecognizer.resumeAfterRewind()
+        case .classic:
+            let work = DispatchWorkItem { isPaused = false }
+            resumeDelay = work
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: work)
+        case .silencePaused:
+            speechRecognizer.resumeAfterRewind()
+            let work = DispatchWorkItem { isPaused = false }
+            resumeDelay = work
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: work)
+        }
+    }
+}
+.onDisappear {
+    rewindTimer?.invalidate()
+    rewindTimer = nil
+    resumeDelay?.cancel()
+    resumeDelay = nil
+}
+```
+
+- [ ] **Step 5: Repeat for FloatingOverlayView**
+
+Apply the same changes to `FloatingOverlayView` (starts around line 1136):
+- Add `handGesture: HandGestureController` property
+- Add `rewindTimer`, `resumeDelay` state
+- Add `rewindWordsPerTick` helper
+- Add the same `onChange(of: handGesture.isHandRaised)` handler with `.onDisappear` cleanup
+- Pass `handGestureController` from where `FloatingOverlayView` is created
+
+**Finding all view instantiation sites:** Search `NotchOverlayController.swift` for `NotchOverlayView(` and `FloatingOverlayView(` to find every place these views are created. Each call site must pass the `handGestureController`. There are typically 1-2 sites per view (in `showPinned`, `showFollowCursor`, `showFloating`, etc.).
+
+**Note:** Fullscreen mode uses `ExternalDisplayView` which is not addressed in this plan — gesture rewind in fullscreen is a future enhancement.
+
+- [ ] **Step 6: Verify build**
+
+```bash
+cd Textream && xcodebuild -scheme Textream -configuration Debug CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" build 2>&1 | tail -5
+```
+
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 7: Build and launch the app**
+
+```bash
+cd Textream && xcodebuild -scheme Textream -configuration Debug CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" build 2>&1 | tail -5
+```
+
+Then launch the app and test:
+1. Load a script and start reading in Word Tracking mode
+2. Raise your hand above shoulder height — script should start rewinding
+3. Raise hand higher — rewind should speed up
+4. Lower hand — speech recognition should resume from new position
+5. Switch to Classic mode, start auto-scroll, raise hand — should rewind `timerWordProgress`
+6. Lower hand — 1.5s pause, then auto-scroll resumes
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Textream/Textream/NotchOverlayController.swift
+git commit -m "feat: integrate hand gesture rewind into overlay views
+
+Start/stop camera with reading sessions. Both NotchOverlayView
+and FloatingOverlayView observe HandGestureController to drive
+rewind in all three listening modes."
+```

--- a/docs/superpowers/plans/2026-03-22-slider-sizing-fonts.md
+++ b/docs/superpowers/plans/2026-03-22-slider-sizing-fonts.md
@@ -1,0 +1,443 @@
+# Slider-Based Window Sizing & Font Controls — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace fixed font size presets with continuous sliders and switch window width from pixels to screen percentages.
+
+**Architecture:** Three settings properties change (`fontSizePreset` → `fontSize`, `notchWidth` → `windowWidthPercent`, new `fullscreenFontSize`). All consumers updated to use the new values. Settings UI switches from preset buttons to sliders.
+
+**Tech Stack:** Swift, SwiftUI, AppKit (NSPanel)
+
+**Spec:** `docs/superpowers/specs/2026-03-22-slider-sizing-fonts-design.md`
+
+---
+
+### Task 1: Update NotchSettings model
+
+**Files:**
+- Modify: `Textream/Textream/NotchSettings.swift`
+
+- [ ] **Step 1: Remove FontSizePreset enum**
+
+Delete lines 10–34 (the entire `FontSizePreset` enum).
+
+- [ ] **Step 2: Replace fontSizePreset property with fontSize**
+
+Replace:
+```swift
+var fontSizePreset: FontSizePreset {
+    didSet { UserDefaults.standard.set(fontSizePreset.rawValue, forKey: "fontSizePreset") }
+}
+```
+With:
+```swift
+var fontSize: CGFloat {
+    didSet { UserDefaults.standard.set(Double(fontSize), forKey: "fontSize") }
+}
+```
+
+- [ ] **Step 3: Add fullscreenFontSize property**
+
+Add after `fontSize`:
+```swift
+var fullscreenFontSize: CGFloat {
+    didSet { UserDefaults.standard.set(Double(fullscreenFontSize), forKey: "fullscreenFontSize") }
+}
+```
+
+- [ ] **Step 4: Replace notchWidth with windowWidthPercent**
+
+Replace:
+```swift
+var notchWidth: CGFloat {
+    didSet { UserDefaults.standard.set(Double(notchWidth), forKey: "notchWidth") }
+}
+```
+With:
+```swift
+var windowWidthPercent: CGFloat {
+    didSet { UserDefaults.standard.set(Double(windowWidthPercent), forKey: "windowWidthPercent") }
+}
+```
+
+- [ ] **Step 5: Update font computed property**
+
+Replace:
+```swift
+var font: NSFont {
+    fontFamilyPreset.font(size: fontSizePreset.pointSize)
+}
+```
+With:
+```swift
+var font: NSFont {
+    fontFamilyPreset.font(size: fontSize)
+}
+```
+
+- [ ] **Step 6: Update constants**
+
+Replace `defaultWidth`, `minWidth`, `maxWidth` while preserving `defaultHeight`, `defaultLocale`, `minHeight`, `maxHeight`:
+```swift
+static let defaultWindowWidthPercent: CGFloat = 0.4
+static let defaultFontSize: CGFloat = 20
+static let defaultFullscreenFontSize: CGFloat = 72
+static let defaultHeight: CGFloat = 150
+static let defaultLocale: String = Locale.current.identifier
+
+static let minHeight: CGFloat = 100
+static let maxHeight: CGFloat = 400
+```
+
+- [ ] **Step 7: Update init()**
+
+Replace the `notchWidth` initialization:
+```swift
+let savedWidth = UserDefaults.standard.double(forKey: "notchWidth")
+self.notchWidth = savedWidth > 0 ? CGFloat(savedWidth) : Self.defaultWidth
+```
+With:
+```swift
+let savedWidthPercent = UserDefaults.standard.double(forKey: "windowWidthPercent")
+self.windowWidthPercent = savedWidthPercent > 0 ? CGFloat(savedWidthPercent) : Self.defaultWindowWidthPercent
+```
+
+Replace the `fontSizePreset` initialization:
+```swift
+self.fontSizePreset = FontSizePreset(rawValue: UserDefaults.standard.string(forKey: "fontSizePreset") ?? "") ?? .lg
+```
+With:
+```swift
+let savedFontSize = UserDefaults.standard.double(forKey: "fontSize")
+self.fontSize = savedFontSize > 0 ? CGFloat(savedFontSize) : Self.defaultFontSize
+let savedFullscreenFontSize = UserDefaults.standard.double(forKey: "fullscreenFontSize")
+self.fullscreenFontSize = savedFullscreenFontSize > 0 ? CGFloat(savedFullscreenFontSize) : Self.defaultFullscreenFontSize
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Textream/Textream/NotchSettings.swift
+git commit -m "refactor: replace font size presets and pixel width with slider-backed settings"
+```
+
+### Task 2: Update NotchOverlayController window sizing
+
+**Files:**
+- Modify: `Textream/Textream/NotchOverlayController.swift`
+
+- [ ] **Step 1: Update showPinned()**
+
+In `showPinned(settings:screen:)`, replace:
+```swift
+let notchWidth = settings.notchWidth
+```
+With:
+```swift
+let notchWidth = screenFrame.width * settings.windowWidthPercent
+```
+
+Note: `screenFrame` is already available in this method. The rest of the method uses `notchWidth` locally so no further changes needed.
+
+- [ ] **Step 2: Update showFloating()**
+
+In `showFloating(settings:screenFrame:)`, replace:
+```swift
+let panelWidth = settings.notchWidth
+```
+With:
+```swift
+let panelWidth = screenFrame.width * settings.windowWidthPercent
+```
+
+Replace the min/max size lines:
+```swift
+panel.minSize = NSSize(width: 280, height: panelHeight)
+panel.maxSize = NSSize(width: 500, height: panelHeight + 350)
+```
+With:
+```swift
+panel.minSize = NSSize(width: screenFrame.width * 0.2, height: panelHeight)
+panel.maxSize = NSSize(width: screenFrame.width * 0.8, height: panelHeight + 350)
+```
+
+- [ ] **Step 3: Update showFollowCursor()**
+
+In `showFollowCursor(settings:screen:)`, replace:
+```swift
+let panelWidth = settings.notchWidth
+```
+With:
+```swift
+let panelWidth = screen.frame.width * settings.windowWidthPercent
+```
+
+- [ ] **Step 4: Update updateFrameTracker()**
+
+In `NotchOverlayView.updateFrameTracker()`, replace:
+```swift
+let fullWidth = NotchSettings.shared.notchWidth
+```
+With:
+```swift
+let fullWidth = (NSScreen.main?.frame.width ?? 1440) * NotchSettings.shared.windowWidthPercent
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Textream/Textream/NotchOverlayController.swift
+git commit -m "refactor: use percentage-based window width in all overlay modes"
+```
+
+### Task 3: Update ExternalDisplayController fullscreen font
+
+**Files:**
+- Modify: `Textream/Textream/ExternalDisplayController.swift`
+
+- [ ] **Step 1: Replace hardcoded font calculation**
+
+In `ExternalDisplayView.prompterView`, replace:
+```swift
+let fontSize = max(48, min(96, geo.size.width / 14))
+```
+and:
+```swift
+font: .systemFont(ofSize: fontSize, weight: .semibold),
+```
+With:
+```swift
+let fontSize = NotchSettings.shared.fullscreenFontSize
+```
+and (using `fontFamilyPreset.font` directly instead of `settings.font`, since `settings.font` uses `fontSize` for pinned/floating, not fullscreen):
+```swift
+font: NotchSettings.shared.fontFamilyPreset.font(size: fontSize),
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add Textream/Textream/ExternalDisplayController.swift
+git commit -m "feat: use user-controlled font size and family for fullscreen teleprompter"
+```
+
+### Task 4: Update SettingsView UI
+
+**Files:**
+- Modify: `Textream/Textream/SettingsView.swift`
+
+- [ ] **Step 1: Update settings panel sizing**
+
+In the settings panel setup (~line 35), replace:
+```swift
+let maxWidth = NotchSettings.maxWidth
+```
+With:
+```swift
+let maxWidth: CGFloat = 500
+```
+
+Also update line 38 and 46 if they reference `NotchSettings.maxWidth` — use the local `maxWidth` constant instead (they likely already do).
+
+- [ ] **Step 2: Replace font size preset picker with slider**
+
+Replace the entire font size preset picker section (lines ~485–517):
+```swift
+// Text Size
+Text("Size")
+    .font(.system(size: 13, weight: .medium))
+
+HStack(spacing: 8) {
+    ForEach(FontSizePreset.allCases) { preset in
+        ...
+    }
+}
+```
+With:
+```swift
+// Text Size
+VStack(alignment: .leading, spacing: 4) {
+    HStack {
+        Text("Font Size")
+            .font(.system(size: 12))
+            .foregroundStyle(.secondary)
+        Spacer()
+        Text("\(Int(settings.fontSize))pt")
+            .font(.system(size: 11, weight: .regular, design: .monospaced))
+            .foregroundStyle(.tertiary)
+    }
+    Slider(
+        value: $settings.fontSize,
+        in: 14...48,
+        step: 1
+    )
+}
+
+Text("Ag")
+    .font(Font(settings.fontFamilyPreset.font(size: settings.fontSize)))
+    .foregroundStyle(.primary)
+    .frame(maxWidth: .infinity, alignment: .center)
+    .padding(.vertical, 4)
+```
+
+- [ ] **Step 3: Replace width pixel slider with percentage slider**
+
+Replace the width slider section (lines ~630–644):
+```swift
+VStack(alignment: .leading, spacing: 4) {
+    HStack {
+        Text("Width")
+            ...
+        Text("\(Int(settings.notchWidth))px")
+            ...
+    }
+    Slider(
+        value: $settings.notchWidth,
+        in: NotchSettings.minWidth...NotchSettings.maxWidth,
+        step: 10
+    )
+}
+```
+With:
+```swift
+VStack(alignment: .leading, spacing: 4) {
+    HStack {
+        Text("Width")
+            .font(.system(size: 12))
+            .foregroundStyle(.secondary)
+        Spacer()
+        Text("\(Int(settings.windowWidthPercent * 100))%")
+            .font(.system(size: 11, weight: .regular, design: .monospaced))
+            .foregroundStyle(.tertiary)
+    }
+    Slider(
+        value: $settings.windowWidthPercent,
+        in: 0.2...0.8,
+        step: 0.05
+    )
+}
+```
+
+- [ ] **Step 4: Add fullscreen font size slider**
+
+After the width/height dimensions section (after the height slider, before the closing braces), add:
+```swift
+Divider()
+
+// Fullscreen Font Size
+VStack(alignment: .leading, spacing: 4) {
+    HStack {
+        Text("Fullscreen Font Size")
+            .font(.system(size: 12))
+            .foregroundStyle(.secondary)
+        Spacer()
+        Text("\(Int(settings.fullscreenFontSize))pt")
+            .font(.system(size: 11, weight: .regular, design: .monospaced))
+            .foregroundStyle(.tertiary)
+    }
+    Slider(
+        value: $settings.fullscreenFontSize,
+        in: 32...200,
+        step: 2
+    )
+}
+```
+
+- [ ] **Step 5: Update notchWidth references in SettingsView preview**
+
+In `SettingsPreviewController.cursorFrame(for:settings:)` (~line 109), replace:
+```swift
+let notchWidth = settings.notchWidth
+```
+With:
+```swift
+let notchWidth = panel.frame.width * settings.windowWidthPercent
+```
+
+In `NotchPreviewContent.body` (~line 157), replace:
+```swift
+let currentWidth = settings.notchWidth
+```
+With:
+```swift
+let screenWidth = NSScreen.main?.frame.width ?? 1440
+let currentWidth = screenWidth * settings.windowWidthPercent
+```
+
+At ~line 217, replace:
+```swift
+.animation(.easeInOut(duration: 0.15), value: settings.notchWidth)
+```
+With:
+```swift
+.animation(.easeInOut(duration: 0.15), value: settings.windowWidthPercent)
+```
+
+- [ ] **Step 6: Update resetAllSettings()**
+
+Replace:
+```swift
+settings.notchWidth = NotchSettings.defaultWidth
+```
+With:
+```swift
+settings.windowWidthPercent = NotchSettings.defaultWindowWidthPercent
+```
+
+Replace:
+```swift
+settings.fontSizePreset = .lg
+```
+With:
+```swift
+settings.fontSize = NotchSettings.defaultFontSize
+settings.fullscreenFontSize = NotchSettings.defaultFullscreenFontSize
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Textream/Textream/SettingsView.swift
+git commit -m "feat: replace font size presets with sliders, add fullscreen font control"
+```
+
+### Task 5: Build and verify
+
+- [ ] **Step 1: Build the project**
+
+```bash
+cd /Users/monster/dev/textream && xcodebuild -project Textream/Textream.xcodeproj -scheme Textream -configuration Debug build 2>&1 | tail -20
+```
+
+Expected: BUILD SUCCEEDED. If there are compilation errors referencing `FontSizePreset`, `notchWidth`, or `maxWidth`, fix them — these are leftover references to removed symbols.
+
+- [ ] **Step 2: Fix any remaining references**
+
+Search for any remaining references to the removed symbols:
+- `FontSizePreset` — should only appear in `BrowserFontSizePreset` context (which is separate)
+- `notchWidth` — should be zero occurrences
+- `fontSizePreset` — should be zero occurrences
+- `NotchSettings.maxWidth`, `NotchSettings.minWidth`, `NotchSettings.defaultWidth` — should be zero occurrences
+- `settings.notchWidth` — should be zero occurrences
+
+- [ ] **Step 3: Launch and test**
+
+Build and launch from CLI:
+```bash
+cd /Users/monster/dev/textream && xcodebuild -project Textream/Textream.xcodeproj -scheme Textream -configuration Debug build 2>&1 | tail -5 && open "$(xcodebuild -project Textream/Textream.xcodeproj -scheme Textream -configuration Debug -showBuildSettings 2>/dev/null | grep ' BUILT_PRODUCTS_DIR' | awk '{print $3}')/Textream.app"
+```
+
+Manual verification:
+1. Open Settings → check font size slider works (14–48pt range)
+2. Check width slider shows percentages (20%–80%)
+3. Check fullscreen font size slider present (32–200pt)
+4. Start pinned overlay → verify width matches percentage
+5. Start floating overlay → verify resizable within percentage bounds
+6. Start fullscreen → verify font size matches slider value
+7. Reset all settings → verify defaults restored
+
+- [ ] **Step 4: Commit any fixes**
+
+```bash
+git add -A && git commit -m "fix: resolve remaining references to removed font size presets"
+```

--- a/docs/superpowers/specs/2026-03-22-hand-gesture-rewind-design.md
+++ b/docs/superpowers/specs/2026-03-22-hand-gesture-rewind-design.md
@@ -1,0 +1,84 @@
+# Hand Gesture Rewind — Design Spec
+
+## Problem
+
+When presenting with Textream, the speaker sometimes needs to go back a few sentences in the script — to re-read a section, correct a mistake, or recover after going off-script. Currently there is no hands-free way to rewind. The speaker would have to walk to the laptop and tap the screen.
+
+## Solution
+
+Use the Mac's front-facing camera and Apple's Vision framework to detect a raised hand. While the hand is raised, the script rewinds continuously. Hand height controls rewind speed — higher hand = faster rewind. Lowering the hand resumes normal operation.
+
+## Hand Detection Pipeline
+
+A new `HandGestureController` class owns camera capture and Vision processing:
+
+1. **AVCaptureSession** captures frames from the default front-facing camera at low resolution (~640x480) and low frame rate (~15fps)
+2. Each frame is processed by **VNDetectHumanHandPoseRequest** which returns hand landmark coordinates
+3. The **wrist Y-position** (0.0 = bottom of frame, 1.0 = top in Vision coordinates) is extracted and smoothed with a rolling average of the last 3-4 frames to reduce jitter
+4. A **raise threshold** (wrist Y > 0.6) determines whether the hand is raised. Below this, the hand is in the speaker's lap or at their side and is ignored
+5. The controller publishes two observable values:
+   - `isHandRaised: Bool`
+   - `handHeight: Float` (0.0 = just above threshold, 1.0 = top of frame)
+
+### Lifecycle
+
+- Camera starts when a reading session begins (`SpeechRecognizer.start()`)
+- Camera stops when the reading session ends (`SpeechRecognizer.stop()`)
+- Camera is NOT running when the app is idle
+
+### Camera Selection
+
+Uses the default front-facing camera. No settings UI for camera selection in this iteration.
+
+## Rewind Behavior
+
+### When hand is raised (`isHandRaised` becomes true):
+
+1. **Pause speech recognition** — stop the audio engine and recognition task without setting `isListening = false` (we intend to resume)
+2. **Start a rewind timer** — a `Timer` firing every 0.25 seconds
+3. Each tick moves `recognizedCharCount` backward by N words (finding previous space characters in `sourceText`). The `handHeight` value controls speed:
+   - Low hand (0.0–0.3): 1 word per tick (~4 words/sec)
+   - Mid hand (0.3–0.7): 2 words per tick (~8 words/sec)
+   - High hand (0.7–1.0): 4 words per tick (~16 words/sec)
+4. `recognizedCharCount` is clamped to never go below 0
+
+### When hand is lowered (`isHandRaised` becomes false):
+
+Behavior depends on the current `ListeningMode`:
+
+- **wordTracking:** Immediately set `matchStartOffset = recognizedCharCount` and call `beginRecognition()` to resume speech tracking from the new position
+- **classic / silencePaused:** Wait 1.5 seconds before resuming auto-scroll from the new position
+
+### Visual Feedback
+
+MarqueeTextView already observes `recognizedCharCount` and animates scroll position — the rewind will visually scroll backward with no additional UI work needed.
+
+## File Organization
+
+### New File
+
+| File | Responsibility |
+|------|---------------|
+| `HandGestureController.swift` | AVCaptureSession setup, VNDetectHumanHandPoseRequest processing, wrist position smoothing, publishes `isHandRaised` and `handHeight` |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `SpeechRecognizer.swift` | Add `HandGestureController` property, start/stop camera with reading session, rewind logic on hand raise, resume logic on hand lower |
+| `Info.plist` | Add `NSCameraUsageDescription` for camera permission prompt |
+
+### Unchanged
+
+MarqueeTextView, NotchSettings, ContentView, SettingsView, BrowserServer, ExternalDisplayController — everything downstream of `recognizedCharCount` is untouched.
+
+## Privacy
+
+The app needs `NSCameraUsageDescription` in `Info.plist`. macOS will prompt for camera permission on first use. The camera feed is processed locally — no frames leave the device.
+
+## Supported Listening Modes
+
+The gesture rewind works in all three listening modes:
+- **Word Tracking** (speech recognition)
+- **Classic** (constant auto-scroll)
+- **Voice-Activated** (silence-paused auto-scroll)

--- a/docs/superpowers/specs/2026-03-22-hand-gesture-rewind-design.md
+++ b/docs/superpowers/specs/2026-03-22-hand-gesture-rewind-design.md
@@ -16,42 +16,60 @@ A new `HandGestureController` class owns camera capture and Vision processing:
 2. Each frame is processed by **VNDetectHumanHandPoseRequest** which returns hand landmark coordinates
 3. The **wrist Y-position** (0.0 = bottom of frame, 1.0 = top in Vision coordinates) is extracted and smoothed with a rolling average of the last 3-4 frames to reduce jitter
 4. A **raise threshold** (wrist Y > 0.6) determines whether the hand is raised. Below this, the hand is in the speaker's lap or at their side and is ignored
-5. The controller publishes two observable values:
+5. If multiple hands are detected, use the one with the highest wrist Y-position
+6. The controller publishes two observable values:
    - `isHandRaised: Bool`
    - `handHeight: Float` (0.0 = just above threshold, 1.0 = top of frame)
 
 ### Lifecycle
 
-- Camera starts when a reading session begins (`SpeechRecognizer.start()`)
-- Camera stops when the reading session ends (`SpeechRecognizer.stop()`)
+- Camera starts when a reading session begins — triggered by the overlay controller's `startReading()` flow, not tied to `SpeechRecognizer.start()` (since classic mode never calls it)
+- Camera stops when the reading session ends
 - Camera is NOT running when the app is idle
+- If no camera is available (Mac Mini, Mac Pro, external displays without camera), the gesture feature is silently disabled
 
 ### Camera Selection
 
 Uses the default front-facing camera. No settings UI for camera selection in this iteration.
 
+### Camera Permission
+
+If camera access is denied, the gesture feature is silently unavailable — no error is shown, no functionality is blocked. The rest of the app works normally. The `NSCameraUsageDescription` key in `Info.plist` provides the permission prompt text.
+
 ## Rewind Behavior
+
+The scroll state lives in different places depending on the listening mode:
+- **wordTracking:** `recognizedCharCount` on `SpeechRecognizer`
+- **classic / silencePaused:** `timerWordProgress` on the overlay controller
+
+The `HandGestureController` publishes `isHandRaised` and `handHeight`. The overlay controller observes these and dispatches rewind to the appropriate state.
 
 ### When hand is raised (`isHandRaised` becomes true):
 
-1. **Pause speech recognition** — stop the audio engine and recognition task without setting `isListening = false` (we intend to resume)
-2. **Start a rewind timer** — a `Timer` firing every 0.25 seconds
-3. Each tick moves `recognizedCharCount` backward by N words (finding previous space characters in `sourceText`). The `handHeight` value controls speed:
-   - Low hand (0.0–0.3): 1 word per tick (~4 words/sec)
-   - Mid hand (0.3–0.7): 2 words per tick (~8 words/sec)
-   - High hand (0.7–1.0): 4 words per tick (~16 words/sec)
-4. `recognizedCharCount` is clamped to never go below 0
+**In wordTracking mode:**
+1. Pause speech recognition — call a new `pauseForRewind()` method on `SpeechRecognizer` that stops the audio engine and recognition task without setting `isListening = false`
+2. Start a rewind timer (every 0.25 seconds) that calls a new `rewindByWords(_ count: Int)` method on `SpeechRecognizer`, which moves `recognizedCharCount` backward by N words (finding previous space characters in `sourceText`) and updates `matchStartOffset` to match
+
+**In classic / silencePaused mode:**
+1. Pause the scroll timer
+2. Start a rewind timer (every 0.25 seconds) that decrements `timerWordProgress` by N words
+
+**Speed (all modes):** The `handHeight` value controls how many words per tick:
+- Low hand (0.0–0.3): 1 word per tick (~4 words/sec)
+- Mid hand (0.3–0.7): 2 words per tick (~8 words/sec)
+- High hand (0.7–1.0): 4 words per tick (~16 words/sec)
+
+Position is clamped to never go below 0.
 
 ### When hand is lowered (`isHandRaised` becomes false):
 
-Behavior depends on the current `ListeningMode`:
+**In wordTracking mode:** Call a new `resumeAfterRewind()` method on `SpeechRecognizer` that sets `matchStartOffset = recognizedCharCount` and calls `beginRecognition()` to resume speech tracking from the new position.
 
-- **wordTracking:** Immediately set `matchStartOffset = recognizedCharCount` and call `beginRecognition()` to resume speech tracking from the new position
-- **classic / silencePaused:** Wait 1.5 seconds before resuming auto-scroll from the new position
+**In classic / silencePaused mode:** Wait 1.5 seconds, then resume the scroll timer from the current `timerWordProgress` position.
 
 ### Visual Feedback
 
-MarqueeTextView already observes `recognizedCharCount` and animates scroll position — the rewind will visually scroll backward with no additional UI work needed.
+In wordTracking mode, MarqueeTextView observes `recognizedCharCount` — rewind scrolls backward automatically. In classic/silencePaused modes, the view observes `timerWordProgress` — same effect. No new UI components needed.
 
 ## File Organization
 
@@ -65,20 +83,17 @@ MarqueeTextView already observes `recognizedCharCount` and animates scroll posit
 
 | File | Change |
 |------|--------|
-| `SpeechRecognizer.swift` | Add `HandGestureController` property, start/stop camera with reading session, rewind logic on hand raise, resume logic on hand lower |
-| `Info.plist` | Add `NSCameraUsageDescription` for camera permission prompt |
+| `SpeechRecognizer.swift` | Add `pauseForRewind()`, `rewindByWords(_:)`, and `resumeAfterRewind()` methods |
+| `NotchOverlayController.swift` | Create and own `HandGestureController`, observe hand state, dispatch rewind to `SpeechRecognizer` or `timerWordProgress` depending on mode, manage rewind timer |
+| `Info.plist` | Add `NSCameraUsageDescription` |
 
 ### Unchanged
 
-MarqueeTextView, NotchSettings, ContentView, SettingsView, BrowserServer, ExternalDisplayController — everything downstream of `recognizedCharCount` is untouched.
-
-## Privacy
-
-The app needs `NSCameraUsageDescription` in `Info.plist`. macOS will prompt for camera permission on first use. The camera feed is processed locally — no frames leave the device.
+MarqueeTextView, NotchSettings, ContentView, SettingsView, BrowserServer, ExternalDisplayController.
 
 ## Supported Listening Modes
 
 The gesture rewind works in all three listening modes:
-- **Word Tracking** (speech recognition)
-- **Classic** (constant auto-scroll)
-- **Voice-Activated** (silence-paused auto-scroll)
+- **Word Tracking** (speech recognition) — rewinds `recognizedCharCount`
+- **Classic** (constant auto-scroll) — rewinds `timerWordProgress`
+- **Voice-Activated** (silence-paused auto-scroll) — rewinds `timerWordProgress`

--- a/docs/superpowers/specs/2026-03-22-slider-sizing-fonts-design.md
+++ b/docs/superpowers/specs/2026-03-22-slider-sizing-fonts-design.md
@@ -1,0 +1,87 @@
+# Slider-Based Window Sizing & Font Controls
+
+**Date:** 2026-03-22
+**Status:** Draft
+
+## Summary
+
+Replace fixed font size presets (XS/SM/LG/XL) with continuous sliders, switch window width from pixel values to screen percentages (20–80%), and add user-controllable font size for fullscreen teleprompter.
+
+## Changes
+
+### 1. Settings Model (NotchSettings.swift)
+
+**Remove:**
+- `FontSizePreset` enum (XS 14pt, SM 16pt, LG 20pt, XL 24pt)
+- `fontSizePreset` property and its UserDefaults persistence
+- `defaultWidth`, `minWidth`, `maxWidth` constants (340px, 310px, 500px)
+
+**Add:**
+- `fontSize: CGFloat` — pinned/floating font size. Default 20, range 14–48. Persisted to UserDefaults.
+- `fullscreenFontSize: CGFloat` — fullscreen font size. Default 72, range 32–200. Persisted to UserDefaults.
+- `defaultWindowWidthPercent: CGFloat` = 0.4
+
+**Replace:**
+- `notchWidth: CGFloat` (pixel value) → `windowWidthPercent: CGFloat` (default 0.4, range 0.2–0.8). Persisted to UserDefaults.
+
+**Update:**
+- `font` computed property: use `fontSize` directly instead of `fontSizePreset.pointSize`
+- `resetAllSettings()`: reset `fontSize` to 20, `fullscreenFontSize` to 72, `windowWidthPercent` to 0.4 (replacing old `notchWidth` and `fontSizePreset` resets)
+
+**Unchanged:** `FontFamilyPreset`, `FontColorPreset`, `CueBrightness`, `textAreaHeight`
+
+### 2. Window Sizing (NotchOverlayController.swift)
+
+**Pinned window (`showPinned()`):**
+- Width = `screen.frame.width * settings.windowWidthPercent`
+- Height unchanged (textAreaHeight-based)
+
+**Floating window (`showFloating()`):**
+- Width = `screen.frame.width * settings.windowWidthPercent`
+- Remove hardcoded 500px max constraint
+- `panel.minSize`: width = `screen.frame.width * 0.2`
+- `panel.maxSize`: width = `screen.frame.width * 0.8`
+
+**Follow cursor (`showFollowCursor()`):**
+- Same percentage-based width calculation as pinned/floating
+
+**`updateFrameTracker()` in NotchOverlayView:**
+- Update to use `settings.windowWidthPercent * screen.frame.width` instead of `settings.notchWidth`
+
+**Fullscreen:** Unchanged (already fills screen)
+
+### 3. Fullscreen Font (ExternalDisplayController.swift)
+
+- Replace `max(48, min(96, geo.size.width / 14))` with `settings.fullscreenFontSize`
+- Use `settings.font` (respecting `fontFamilyPreset`) instead of hardcoded `.systemFont`
+
+### 4. Settings UI (SettingsView.swift)
+
+**Replace font size preset picker** (4 XS/SM/LG/XL buttons) with:
+- "Font Size" slider, range 14–48pt, shows current value
+- Live preview text sample using slider value
+
+**Replace width pixel slider** (310–500px) with:
+- "Window Width" slider, range 20%–80%, shows current percentage
+
+**Add:**
+- "Fullscreen Font Size" slider, range 32–200pt, shows current value
+
+**Update:**
+- Settings panel sizing: replace `NotchSettings.maxWidth` references with a fixed reasonable width (e.g., 500px) for the settings window itself
+- `resetAllSettings()` button: update to reset new properties
+
+**Unchanged:** Font family picker, height slider, color pickers, cue brightness
+
+## Migration
+
+Existing UserDefaults keys for `fontSizePreset` and `notchWidth` become stale. New keys (`fontSize`, `fullscreenFontSize`, `windowWidthPercent`) initialize to defaults on first launch. No migration needed — old values are simply ignored.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `NotchSettings.swift` | Remove FontSizePreset enum, add slider-backed properties, update defaults/reset |
+| `NotchOverlayController.swift` | Percentage-based width in showPinned, showFloating, showFollowCursor, updateFrameTracker |
+| `ExternalDisplayController.swift` | Use settings.fullscreenFontSize and settings.font |
+| `SettingsView.swift` | Replace preset buttons with sliders, fix settings panel sizing |


### PR DESCRIPTION
     1	## Summary
     2	
     3	This combines two open PRs that both went stale against `master` and have a build dependency on each other:
     4	
     5	- #25 — Hands-free rewind: raise your hand to go back (adds `HandGestureController`, camera-based rewind)
     6	- #26 — Flexible window sizing, unified settings, and keyboard shortcuts (depends on `HandGestureController` from #25, though it doesn't add the file itself — it must merge after #25)
     7	
     8	Both were marked `CONFLICTING` against current `master` since master has moved on (voice-tracking bug fixes, start-from-selected-page fix, overlay transparency feature) touching the same files. This PR merges #25 then #26 in order with conflicts resolved by hand:
     9	
    10	- **SpeechRecognizer.swift**: kept master's split `cleanupRecognitionTask`/`cleanupAudioEngine`/`cleanupRecognition` structure (from a prior refactor) while layering in `pauseForRewind`/`rewindByWords`/`resumeAfterRewind` from #25, then applied #26's bounds-safety fix (guard empty text, clamp offset) to `rewindByWords`.
    11	- **SettingsView.swift**: #26 moves the notch display-mode picker from the `.pinned` section into the `.floating` section (and merges it with Follow Cursor/Glass Effect) — but #26 predates the "overlay transparency" feature that master added under `.pinned`. Restored a `.pinned`-scoped block for the Transparency toggle (transparency only applies in pinned mode per the `isTransparent` check elsewhere in the file) alongside #26's floating-section consolidation.
    12	- **NotchOverlayController.swift**: kept the `settings.handGestureRewind` toggle guard (from #25's settings toggle commit) around gesture-controller start/stop, combined with #26's `guard panel != nil` check and `onHandStateChanged = nil` cleanup on dismiss/forceClose.
    13	
    14	Verified the merged tree builds clean (`xcodebuild ... build` → `BUILD SUCCEEDED`, code signing disabled locally to test compilation only).
    15	
    16	## Test plan
    17	
    18	- [ ] Build and run in Xcode with a real signing identity
    19	- [ ] Raise/lower hand during word tracking — verify pause/rewind/resume still works
    20	- [ ] Toggle Hand Gesture Rewind off in Guidance settings — verify camera doesn't start
    21	- [ ] Adjust width/height sliders — verify live panel resize
    22	- [ ] Pinned mode: toggle Transparency — verify slider appears and overlay becomes see-through
    23	- [ ] Floating mode: verify Display (Follow Mouse/Fixed), Follow Cursor, and Glass Effect all show together
    24	- [ ] Cmd+Enter / Cmd+R / Escape shortcuts work as before