### PR TITLE
Remote: scrolling the remote scrubs the live prompter

### DIFF
--- a/Textream/Textream/BrowserServer.swift
+++ b/Textream/Textream/BrowserServer.swift
@@ -28,7 +28,7 @@ struct BrowserState: Codable {
 // MARK: - Browser Command (remote -> app)
 
 struct BrowserCommand: Codable {
-    let type: String        // "seek"
+    let type: String        // "scrub" | "seek"
     let charOffset: Int?
 }
 
@@ -47,8 +47,12 @@ class BrowserServer {
     private weak var speechRecognizer: SpeechRecognizer?
     private var timerWordProgress: Double = 0
     private var contentActive: Bool = false
+    private var scrubCharOffset: Int?
 
-    /// Called when the remote asks to continue reading from a tapped word.
+    /// Called continuously while the remote is being scrolled.
+    var onScrub: ((Int) -> Void)?
+
+    /// Called when the remote settles on a position to continue reading from.
     var onSeek: ((Int) -> Void)?
 
     var httpPort: UInt16 { NotchSettings.shared.browserServerPort }
@@ -86,6 +90,7 @@ class BrowserServer {
         self.totalCharCount = totalCharCount
         self.hasNextPage = hasNextPage
         self.timerWordProgress = 0
+        self.scrubCharOffset = nil
         self.contentActive = true
         startBroadcasting()
     }
@@ -95,6 +100,7 @@ class BrowserServer {
         self.totalCharCount = totalCharCount
         self.hasNextPage = hasNextPage
         self.timerWordProgress = 0
+        self.scrubCharOffset = nil
     }
 
     func hideContent() {
@@ -190,6 +196,10 @@ class BrowserServer {
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
             switch command.type {
+            case "scrub":
+                if let charOffset = command.charOffset {
+                    self.onScrub?(max(0, min(charOffset, self.totalCharCount)))
+                }
             case "seek":
                 if let charOffset = command.charOffset {
                     self.onSeek?(max(0, min(charOffset, self.totalCharCount)))
@@ -200,9 +210,15 @@ class BrowserServer {
         }
     }
 
-    /// Move this server's own scroll progress (classic / silence-paused modes)
-    /// so the remote reflects a seek immediately.
+    /// Follow a live scroll without committing it.
+    func applyScrub(charOffset: Int) {
+        scrubCharOffset = max(0, min(charOffset, totalCharCount))
+    }
+
+    /// Commit a position: drop the scrub override and move the scroll progress
+    /// so classic / silence-paused modes carry on from here.
     func applySeek(charOffset: Int) {
+        scrubCharOffset = nil
         timerWordProgress = wordProgressForCharOffset(charOffset)
     }
 
@@ -237,7 +253,8 @@ class BrowserServer {
             charCount = charOffsetForWordProgress(timerWordProgress)
         }
 
-        let effective = min(charCount, totalCharCount)
+        // While the remote is being scrolled, everyone follows the scrub position
+        let effective = scrubCharOffset ?? min(charCount, totalCharCount)
         let rawDone = totalCharCount > 0 && effective >= totalCharCount
         // In classic/silence-paused modes on the last page, suppress Done so the
         // browser keeps showing the prompter text (speaker may still be talking).
@@ -387,17 +404,6 @@ class BrowserServer {
         .w{cursor:pointer;-webkit-tap-highlight-color:transparent}
         .w:active{opacity:.55}
 
-        /* "Back to live" pill, shown while manually scrolled away */
-        #live-pill{position:absolute;left:50%;transform:translateX(-50%);
-          bottom:18px;z-index:5;display:none;align-items:center;gap:8px;
-          padding:11px 20px;border-radius:999px;cursor:pointer;
-          background:rgba(255,255,255,.14);color:#fff;
-          font-size:15px;font-weight:600;
-          border:1px solid rgba(255,255,255,.2);
-          backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px)}
-        #live-pill.show{display:flex}
-        #live-pill .dot{width:8px;height:8px;border-radius:50%;background:#facc15}
-
         /* Text: match ExternalDisplayView font sizing: max(48, min(96, width/14)) */
         #text-container{
           font-size:clamp(48px,calc(100vw / 14),96px);
@@ -454,7 +460,6 @@ class BrowserServer {
         <div id="main">
           <div id="prompter-wrap">
             <div id="prompter"><div id="text-container"></div></div>
-            <div id="live-pill"><span class="dot"></span><span>Back to live</span></div>
           </div>
           <div id="bar">
             <div id="waveform"></div>
@@ -470,7 +475,8 @@ class BrowserServer {
 
         <script>
         const WSP=\(wsPort),host=location.hostname;
-        let ws,rt,prevWordKey='',scrollTgt=null,manual=false;
+        let ws,rt,prevWordKey='',scrollTgt=null,manual=false,
+            lastScrub=0,scrubEndTimer=null;
 
         /* ---- helpers ---- */
 
@@ -490,16 +496,30 @@ class BrowserServer {
         // Send a command back to the app
         function send(obj){if(ws&&ws.readyState===1)ws.send(JSON.stringify(obj));}
 
-        // Manual mode: user scrolled away, so stop auto-following the active word
-        function setManual(on){
-          manual=on;
-          document.getElementById('live-pill').classList.toggle('show',on);
+        // Manual mode: the user is driving, so stop auto-following the active word
+        function setManual(on){manual=on;}
+
+        // Character offset of the word nearest the reading anchor. Binary search,
+        // so this stays cheap on long scripts while scrolling.
+        function centerCharOffset(){
+          const p=document.getElementById('prompter'),
+                spans=document.getElementById('text-container').children;
+          if(!spans.length)return 0;
+          const pr=p.getBoundingClientRect(),targetY=pr.top+pr.height*0.4;
+          let lo=0,hi=spans.length-1,best=0;
+          while(lo<=hi){
+            const mid=(lo+hi)>>1;
+            if(spans[mid].getBoundingClientRect().top<=targetY){best=mid;lo=mid+1}
+            else{hi=mid-1}
+          }
+          return parseInt(spans[best].dataset.s);
         }
 
-        // Re-centre on the word currently being read
-        function backToLive(){
+        // Settled after a scroll: commit the position and resume auto-follow
+        function commitScrub(){
+          scrubEndTimer=null;
+          send({type:'seek',charOffset:centerCharOffset()});
           setManual(false);
-          if(scrollTgt)scrollTgt.scrollIntoView({behavior:'smooth',block:'center'});
         }
 
         // Detect annotation words: [bracket] or emoji-only (no letters/digits)
@@ -665,21 +685,33 @@ class BrowserServer {
           document.getElementById('mic-dot').classList.toggle('on',!!s.isListening);
         }
 
-        // Scrolling by hand suspends auto-follow so you can read ahead or back
+        // Scrolling by hand takes over from auto-follow...
         const promptEl=document.getElementById('prompter');
         ['wheel','touchmove'].forEach(function(ev){
           promptEl.addEventListener(ev,function(){setManual(true)},{passive:true});
         });
 
+        // ...and drags the live prompter along with it. Throttled while moving,
+        // committed once the scroll (including momentum) settles.
+        promptEl.addEventListener('scroll',function(){
+          if(!manual)return;            // ignore our own auto-scrolling
+          const now=Date.now();
+          if(now-lastScrub>100){
+            lastScrub=now;
+            send({type:'scrub',charOffset:centerCharOffset()});
+          }
+          clearTimeout(scrubEndTimer);
+          scrubEndTimer=setTimeout(commitScrub,250);
+        },{passive:true});
+
         // Tap a word to continue reading from there
         document.getElementById('text-container').addEventListener('click',function(e){
           const sp=e.target.closest?e.target.closest('.w'):null;
           if(!sp)return;
+          clearTimeout(scrubEndTimer);scrubEndTimer=null;
           send({type:'seek',charOffset:parseInt(sp.dataset.s)});
           setManual(false);
         });
-
-        document.getElementById('live-pill').addEventListener('click',backToLive);
 
         // Init waveform bars
         const wfInit=document.getElementById('waveform');

--- a/Textream/Textream/BrowserServer.swift
+++ b/Textream/Textream/BrowserServer.swift
@@ -25,6 +25,13 @@ struct BrowserState: Codable {
     let lastSpokenText: String
 }
 
+// MARK: - Browser Command (remote -> app)
+
+struct BrowserCommand: Codable {
+    let type: String        // "seek"
+    let charOffset: Int?
+}
+
 // MARK: - Browser Server
 
 class BrowserServer {
@@ -40,6 +47,9 @@ class BrowserServer {
     private weak var speechRecognizer: SpeechRecognizer?
     private var timerWordProgress: Double = 0
     private var contentActive: Bool = false
+
+    /// Called when the remote asks to continue reading from a tapped word.
+    var onSeek: ((Int) -> Void)?
 
     var httpPort: UInt16 { NotchSettings.shared.browserServerPort }
     var wsPort: UInt16 { httpPort + 1 }
@@ -167,10 +177,33 @@ class BrowserServer {
     }
 
     private func receiveWSMessage(_ conn: NWConnection) {
-        conn.receiveMessage { [weak self] _, _, _, error in
+        conn.receiveMessage { [weak self] data, _, _, error in
             if error != nil { conn.cancel(); return }
+            if let data { self?.handleIncomingMessage(data) }
             self?.receiveWSMessage(conn)
         }
+    }
+
+    private func handleIncomingMessage(_ data: Data) {
+        guard let command = try? JSONDecoder().decode(BrowserCommand.self, from: data) else { return }
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            switch command.type {
+            case "seek":
+                if let charOffset = command.charOffset {
+                    self.onSeek?(max(0, min(charOffset, self.totalCharCount)))
+                }
+            default:
+                break
+            }
+        }
+    }
+
+    /// Move this server's own scroll progress (classic / silence-paused modes)
+    /// so the remote reflects a seek immediately.
+    func applySeek(charOffset: Int) {
+        timerWordProgress = wordProgressForCharOffset(charOffset)
     }
 
     // MARK: - Broadcasting
@@ -249,6 +282,19 @@ class BrowserServer {
     }
 
     // MARK: - Helpers
+
+    private func wordProgressForCharOffset(_ charOffset: Int) -> Double {
+        var offset = 0
+        for (i, word) in words.enumerated() {
+            let end = offset + word.count
+            if charOffset <= end {
+                let frac = Double(charOffset - offset) / Double(max(1, word.count))
+                return Double(i) + frac
+            }
+            offset = end + 1
+        }
+        return Double(words.count)
+    }
 
     private func charOffsetForWordProgress(_ progress: Double) -> Int {
         let wholeWord = Int(progress)
@@ -337,6 +383,21 @@ class BrowserServer {
           -webkit-overflow-scrolling:touch;scroll-behavior:smooth}
         #prompter::-webkit-scrollbar{display:none}
 
+        /* Words are tappable to continue reading from there */
+        .w{cursor:pointer;-webkit-tap-highlight-color:transparent}
+        .w:active{opacity:.55}
+
+        /* "Back to live" pill, shown while manually scrolled away */
+        #live-pill{position:absolute;left:50%;transform:translateX(-50%);
+          bottom:18px;z-index:5;display:none;align-items:center;gap:8px;
+          padding:11px 20px;border-radius:999px;cursor:pointer;
+          background:rgba(255,255,255,.14);color:#fff;
+          font-size:15px;font-weight:600;
+          border:1px solid rgba(255,255,255,.2);
+          backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px)}
+        #live-pill.show{display:flex}
+        #live-pill .dot{width:8px;height:8px;border-radius:50%;background:#facc15}
+
         /* Text: match ExternalDisplayView font sizing: max(48, min(96, width/14)) */
         #text-container{
           font-size:clamp(48px,calc(100vw / 14),96px);
@@ -393,6 +454,7 @@ class BrowserServer {
         <div id="main">
           <div id="prompter-wrap">
             <div id="prompter"><div id="text-container"></div></div>
+            <div id="live-pill"><span class="dot"></span><span>Back to live</span></div>
           </div>
           <div id="bar">
             <div id="waveform"></div>
@@ -408,7 +470,7 @@ class BrowserServer {
 
         <script>
         const WSP=\(wsPort),host=location.hostname;
-        let ws,rt,prevWordKey='',scrollTgt=null;
+        let ws,rt,prevWordKey='',scrollTgt=null,manual=false;
 
         /* ---- helpers ---- */
 
@@ -424,6 +486,21 @@ class BrowserServer {
           return m?m.slice(0,3).map(Number):[255,255,255];
         }
         function rgba(rgb,a){return 'rgba('+rgb[0]+','+rgb[1]+','+rgb[2]+','+a+')';}
+
+        // Send a command back to the app
+        function send(obj){if(ws&&ws.readyState===1)ws.send(JSON.stringify(obj));}
+
+        // Manual mode: user scrolled away, so stop auto-following the active word
+        function setManual(on){
+          manual=on;
+          document.getElementById('live-pill').classList.toggle('show',on);
+        }
+
+        // Re-centre on the word currently being read
+        function backToLive(){
+          setManual(false);
+          if(scrollTgt)scrollTgt.scrollIntoView({behavior:'smooth',block:'center'});
+        }
 
         // Detect annotation words: [bracket] or emoji-only (no letters/digits)
         function isAnnotation(w){
@@ -490,6 +567,7 @@ class BrowserServer {
               cp+=wd.length+1;
             }
             prevWordKey=wordKey;
+            setManual(false);
           }
 
           // Find the next-word index (first non-fully-lit non-annotation)
@@ -548,8 +626,8 @@ class BrowserServer {
             }
           }
 
-          // Auto-scroll: keep active word centered
-          if(scrollTgt){
+          // Auto-scroll: keep active word centered (suspended while scrolling manually)
+          if(scrollTgt&&!manual){
             const p=document.getElementById('prompter'),
                   r=scrollTgt.getBoundingClientRect(),
                   pr=p.getBoundingClientRect(),
@@ -586,6 +664,22 @@ class BrowserServer {
           // Mic indicator
           document.getElementById('mic-dot').classList.toggle('on',!!s.isListening);
         }
+
+        // Scrolling by hand suspends auto-follow so you can read ahead or back
+        const promptEl=document.getElementById('prompter');
+        ['wheel','touchmove'].forEach(function(ev){
+          promptEl.addEventListener(ev,function(){setManual(true)},{passive:true});
+        });
+
+        // Tap a word to continue reading from there
+        document.getElementById('text-container').addEventListener('click',function(e){
+          const sp=e.target.closest?e.target.closest('.w'):null;
+          if(!sp)return;
+          send({type:'seek',charOffset:parseInt(sp.dataset.s)});
+          setManual(false);
+        });
+
+        document.getElementById('live-pill').addEventListener('click',backToLive);
 
         // Init waveform bars
         const wfInit=document.getElementById('waveform');

--- a/Textream/Textream/ExternalDisplayController.swift
+++ b/Textream/Textream/ExternalDisplayController.swift
@@ -210,6 +210,9 @@ struct ExternalDisplayView: View {
                 break
             }
         }
+        .onChange(of: content.seekToken) { _, _ in
+            timerWordProgress = wordProgressForCharOffset(content.seekCharOffset)
+        }
     }
 
     private var prompterView: some View {

--- a/Textream/Textream/ExternalDisplayController.swift
+++ b/Textream/Textream/ExternalDisplayController.swift
@@ -151,6 +151,8 @@ struct ExternalDisplayView: View {
     }
 
     private var effectiveCharCount: Int {
+        // While a remote is scrubbing, every surface follows the scrub position
+        if let scrub = content.scrubCharOffset { return scrub }
         switch listeningMode {
         case .wordTracking:
             return speechRecognizer.recognizedCharCount

--- a/Textream/Textream/NotchOverlayController.swift
+++ b/Textream/Textream/NotchOverlayController.swift
@@ -36,6 +36,11 @@ class OverlayContent {
     var totalCharCount: Int = 0
     var hasNextPage: Bool = false
 
+    // Seek requested from a remote. `seekToken` increments on every request so
+    // observing views react even when the same offset is sent twice.
+    var seekCharOffset: Int = 0
+    var seekToken: Int = 0
+
     // Page picker
     var pageCount: Int = 1
     var currentPageIndex: Int = 0
@@ -853,6 +858,9 @@ struct NotchOverlayView: View {
         .onChange(of: content.totalCharCount) { _, _ in
             timerWordProgress = 0
         }
+        .onChange(of: content.seekToken) { _, _ in
+            timerWordProgress = wordProgressForCharOffset(content.seekCharOffset)
+        }
     }
 
     private func updateFrameTracker() {
@@ -1365,6 +1373,9 @@ struct FloatingOverlayView: View {
         }
         .onChange(of: content.totalCharCount) { _, _ in
             timerWordProgress = 0
+        }
+        .onChange(of: content.seekToken) { _, _ in
+            timerWordProgress = wordProgressForCharOffset(content.seekCharOffset)
         }
     }
 

--- a/Textream/Textream/NotchOverlayController.swift
+++ b/Textream/Textream/NotchOverlayController.swift
@@ -41,6 +41,10 @@ class OverlayContent {
     var seekCharOffset: Int = 0
     var seekToken: Int = 0
 
+    // Live position while a remote is being scrolled. Non-nil overrides the
+    // normal position on every surface until the scroll settles.
+    var scrubCharOffset: Int? = nil
+
     // Page picker
     var pageCount: Int = 1
     var currentPageIndex: Int = 0
@@ -703,6 +707,8 @@ struct NotchOverlayView: View {
     }
 
     private var effectiveCharCount: Int {
+        // While a remote is scrubbing, every surface follows the scrub position
+        if let scrub = content.scrubCharOffset { return scrub }
         switch listeningMode {
         case .wordTracking:
             return speechRecognizer.recognizedCharCount
@@ -1267,6 +1273,8 @@ struct FloatingOverlayView: View {
     }
 
     private var effectiveCharCount: Int {
+        // While a remote is scrubbing, every surface follows the scrub position
+        if let scrub = content.scrubCharOffset { return scrub }
         switch listeningMode {
         case .wordTracking:
             return speechRecognizer.recognizedCharCount

--- a/Textream/Textream/TextreamService.swift
+++ b/Textream/Textream/TextreamService.swift
@@ -309,10 +309,31 @@ class TextreamService: NSObject, ObservableObject {
         if NotchSettings.shared.browserServerEnabled {
             if !browserServer.isRunning {
                 browserServer.start()
+                wireBrowserCallbacks()
             }
         } else {
             browserServer.stop()
         }
+    }
+
+    private func wireBrowserCallbacks() {
+        browserServer.onSeek = { [weak self] charOffset in
+            self?.seek(toCharOffset: charOffset)
+        }
+    }
+
+    /// Continue reading from an arbitrary point, requested by the remote.
+    /// Applies to every surface: word-tracking follows the speech recognizer,
+    /// while classic / silence-paused modes are driven by the scroll progress.
+    func seek(toCharOffset charOffset: Int) {
+        overlayController.speechRecognizer.jumpTo(charOffset: charOffset)
+
+        for content in [overlayController.overlayContent, externalDisplayController.overlayContent] {
+            content.seekCharOffset = charOffset
+            content.seekToken &+= 1
+        }
+
+        browserServer.applySeek(charOffset: charOffset)
     }
 
     // MARK: - Director Server

--- a/Textream/Textream/TextreamService.swift
+++ b/Textream/Textream/TextreamService.swift
@@ -317,9 +317,22 @@ class TextreamService: NSObject, ObservableObject {
     }
 
     private func wireBrowserCallbacks() {
+        browserServer.onScrub = { [weak self] charOffset in
+            self?.scrub(toCharOffset: charOffset)
+        }
         browserServer.onSeek = { [weak self] charOffset in
             self?.seek(toCharOffset: charOffset)
         }
+    }
+
+    /// Follow a remote's live scroll. Every surface shows the scrubbed position,
+    /// but the speech recognizer is deliberately left alone until the scroll
+    /// settles so that dragging can't restart recognition on every update.
+    func scrub(toCharOffset charOffset: Int) {
+        for content in [overlayController.overlayContent, externalDisplayController.overlayContent] {
+            content.scrubCharOffset = charOffset
+        }
+        browserServer.applyScrub(charOffset: charOffset)
     }
 
     /// Continue reading from an arbitrary point, requested by the remote.
@@ -329,6 +342,7 @@ class TextreamService: NSObject, ObservableObject {
         overlayController.speechRecognizer.jumpTo(charOffset: charOffset)
 
         for content in [overlayController.overlayContent, externalDisplayController.overlayContent] {
+            content.scrubCharOffset = nil
             content.seekCharOffset = charOffset
             content.seekToken &+= 1
         }


### PR DESCRIPTION
## What & why

The browser remote is currently **view-only**. It auto-scrolls to keep the active word centred, and its WebSocket `receiveMessage` handler discards every inbound message. That means while presenting you can't glance back at what you just said, skim ahead, or skip a passage you decided not to read and carry on from a different point. Any attempt to scroll is undone within 100ms by the next broadcast.

## What this PR does

**Scrolling the remote drags the live prompter with it.** The remote stops being a passive mirror and becomes a control surface.

- **Scroll = scrub.** While you scroll, the remote streams `{type:"scrub",charOffset:N}` updates (throttled to ~10/s) carrying the word at the reading anchor. Every surface — notch, floating, fullscreen, external display — follows along, in all three listening modes.
- **Commit on settle.** 250ms after the last scroll event, a `{type:"seek"}` commits the position and auto-follow resumes, so reading carries on from where you stopped.
- **Tap any word** to jump straight there.

## Implementation notes

- `BrowserServer` gains a small inbound-command path (`BrowserCommand`, `handleIncomingMessage`, `onScrub`/`onSeek`) modelled on the existing `DirectorServer` pattern rather than inventing a new one. Unknown command types are ignored and offsets are clamped to the script length.
- Scrub is a **display-level override**: `OverlayContent.scrubCharOffset` short-circuits `effectiveCharCount` on all three prompter views. This matters because in word-tracking mode the position comes solely from `speechRecognizer.recognizedCharCount`, so a visual-only path wouldn't move it.
- **The speech recognizer is deliberately untouched while scrubbing.** `jumpTo()` tears down and restarts the audio engine for jumps over 500 chars, so calling it on every scroll update would thrash recognition. It is resynced once, by the committing seek, when the scroll settles.
- Scrub updates are only sent while the user is driving, so the prompter's own `scrollIntoView` can't be mistaken for user input.
- No new setting: the behaviour is inert until you actually scroll or tap.

## Testing

- Builds clean (`xcodebuild`, Debug/macOS).
- The generated remote page was extracted, its script syntax-checked, and driven in a real browser with a stubbed socket. Asserted:
  - a simulated finger drag emits throttled scrubs that advance with the drag (12 scroll events → 3 sends; a 40-event burst adds 0)
  - the scrub offset exactly matches the word at the reading anchor
  - auto-follow stays suspended for the whole drag, and no seek is committed mid-drag
  - exactly **one** seek commits on settle, at the final scrubbed position
  - manual mode clears afterwards and auto-follow resumes
  - programmatic auto-scroll produces no scrub
  - tapping word #42 emits exactly `{type:"seek",charOffset:284}`, the correct offset for that word

Not yet verified end-to-end over a real phone→Mac socket; that needs a live reading session.
