### PR TITLE
fix: unify scroll anchor and add smooth-mode lookahead

### DIFF
--- a/Textream/Textream/MarqueeTextView.swift
+++ b/Textream/Textream/MarqueeTextView.swift
@@ -246,24 +246,33 @@ struct SpeechScrollView: View {
         )
     }
 
+    /// Y position in the viewport where the active word is anchored.
+    /// Smooth modes (classic/silence-paused) anchor in the lower third so read
+    /// text stays visible above while the next lines remain visible below —
+    /// anchoring at the very bottom leaves the speaker no lookahead.
+    /// wordProgressAtCurrentOffset must use the same anchor, otherwise
+    /// releasing a manual scroll snaps the text by the difference.
+    private func readingAnchorY(containerHeight: CGFloat) -> CGFloat {
+        smoothScroll ? containerHeight * 0.7 : containerHeight * 0.5
+    }
+
     private func recalcCenter(containerHeight: CGFloat) {
-        let center = containerHeight * 0.5
+        let anchor = readingAnchorY(containerHeight: containerHeight)
 
         if smoothScroll {
-            // Classic/silence-paused: anchor active word near the bottom, scrolling up
-            let bottomAnchor = containerHeight - 20
+            // Classic/silence-paused: continuous word progress, interpolated
             let wordIdx = Int(smoothWordProgress)
             let fraction = smoothWordProgress - Double(wordIdx)
             let clampedIdx = max(0, min(wordIdx, words.count - 1))
             guard let wordY = wordYPositions[clampedIdx] else { return }
             let nextY = wordYPositions[clampedIdx + 1] ?? wordY
             let interpolatedY = wordY + (nextY - wordY) * CGFloat(fraction)
-            scrollOffset = bottomAnchor - interpolatedY
+            scrollOffset = anchor - interpolatedY
         } else {
-            // Word-tracking/voice-activated: active word at vertical center
+            // Word tracking: active word at vertical center
             let wordIdx = activeWordIndex()
             if let wordY = wordYPositions[wordIdx] {
-                let target = center - wordY
+                let target = anchor - wordY
                 // Only update if it actually changed to avoid redundant animations
                 if abs(scrollOffset - target) > 1 {
                     scrollOffset = target
@@ -274,9 +283,9 @@ struct SpeechScrollView: View {
 
     /// Find the word progress at the current visual position (scrollOffset + manualOffset)
     private func wordProgressAtCurrentOffset() -> Double {
-        let center = containerHeight * 0.5
-        // The Y position currently at the center of the view
-        let targetY = center - (scrollOffset + manualOffset)
+        let anchor = readingAnchorY(containerHeight: containerHeight)
+        // The Y position currently at the reading anchor line
+        let targetY = anchor - (scrollOffset + manualOffset)
 
         // Find the closest word and interpolate
         let sorted = wordYPositions.sorted { $0.key < $1.key }


### PR DESCRIPTION
Supersedes #64.

Two coupled scroll bugs in smooth modes (classic / silence-paused), one file (`MarqueeTextView.swift`):

**1. Anchor mismatch on manual-scroll release.** `recalcCenter()` anchors the active word and `wordProgressAtCurrentOffset()` reads the word back at a reference line, but the two used different reference points — the active word was anchored near the bottom edge while the resume path read from the vertical center. Releasing a manual scroll snapped the text by roughly half the window height. Both now share one `readingAnchorY()` helper.

**2. No lookahead.** The smooth-mode anchor sat 20pt above the bottom, so any word past the timer position was below the visible window. It now sits at 70% of viewport height, keeping a couple of upcoming lines visible. Word-tracking mode is unchanged (active word still centered).

**Relationship to #64:** this is the still-relevant half of #64, rebased onto current master as a single commit. The other two fixes there were independently superseded upstream — the word-level-matcher-on-divergence fix by the `SpeechTextAlignment.bestOffset` refactor, and the `isSpeaking` hysteresis by `VoiceActivityDetector`.

Built green on master (1.6.2); verified by manual scroll + release in both smooth modes.
