### PR TITLE
Fix RTL rendering for Hebrew and Arabic scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Textream/Textream.xcodeproj/project.pbxproj
           git commit -m "Bump version to ${{ steps.version.outputs.number }}" || echo "No changes to commit"
-          git push origin HEAD:refs/heads/main || echo "Push skipped"
+          git push origin HEAD:refs/heads/master || echo "Push skipped"
 
   build:
     needs: version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,17 +146,17 @@ jobs:
 
             if MacOS.version >= :tahoe
               sha256 "${SHA256_26}"
-              url "https://github.com/f/textream/releases/download/${VERSION}/Textream.dmg"
+              url "https://github.com/f/textream/releases/download/v#{version}/Textream.dmg"
             else
               sha256 "${SHA256_15}"
-              url "https://github.com/f/textream/releases/download/${VERSION}/Textream-macos15.dmg"
+              url "https://github.com/f/textream/releases/download/v#{version}/Textream-macos15.dmg"
             end
 
             name "Textream"
             desc "macOS teleprompter that highlights your script in real-time as you speak"
             homepage "https://github.com/f/textream"
 
-            depends_on macos: ">= :sequoia"
+            depends_on macos: :sequoia
 
             app "Textream.app"
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,19 @@ View your teleprompter on **any device** — phone, tablet, or another computer 
 - **Configurable port** — Default port 7373, adjustable in advanced settings.
 - **Fully local** — All traffic stays on your local network. Nothing leaves your Wi-Fi.
 
+### Director Mode
+
+Let someone else control your teleprompter remotely. A director can write, edit, and push scripts to your teleprompter in real time from any browser.
+
+- **Enable in Settings → Director** — Starts a dedicated HTTP + WebSocket server (default port 7575).
+- **Remote web UI** — The director opens a mobile-friendly web page with a full-featured script editor.
+- **Live text editing** — The director types or pastes a script, hits Go, and your teleprompter starts immediately with word tracking.
+- **Read-locked highlighting** — Already-read text is highlighted and locked in the web editor. Only unread text remains editable.
+- **Real-time sync** — Word progress, waveform, mic status, and audio levels stream to the director's browser at 10 Hz.
+- **Single-page mode** — Director mode works with a single page of text. Multi-page scripts are not used.
+- **Editor disabled** — When director mode is active, the macOS editor is replaced with a QR code overlay so the director has full control.
+- **QR code** — Scan or share the QR code from Settings or the editor overlay to connect the director instantly.
+
 ### File Support
 
 - **PowerPoint notes import** — Drop a .pptx file to extract presenter notes as pages. For Keynote or Google Slides, export to PowerPoint first.
@@ -189,6 +202,7 @@ Textream/
     ├── SettingsView.swift             # Tabbed settings UI
     ├── MarqueeTextView.swift          # Word flow layout and highlighting
     ├── BrowserServer.swift            # Remote connection HTTP + WebSocket server
+    ├── DirectorServer.swift           # Director mode HTTP + WebSocket server
     ├── PresentationNotesExtractor.swift # PPTX presenter notes extraction
     ├── UpdateChecker.swift            # GitHub release update checker
     └── Assets.xcassets/               # App icon and colors

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,67 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| Latest release | ✅ |
+| Older releases | ❌ |
+
+Only the latest release receives security updates. Please keep Textream up to date.
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in Textream, **please do not open a public issue.**
+
+Instead, report it privately:
+
+- **Email:** [fka@fka.dev](mailto:fka@fka.dev)
+- **Subject:** `[SECURITY] Textream — <brief description>`
+
+Please include:
+
+1. A description of the vulnerability
+2. Steps to reproduce the issue
+3. Potential impact
+4. Suggested fix (if any)
+
+You should receive an acknowledgment within **48 hours**. Once confirmed, a fix will be prioritized and released as soon as possible.
+
+## Security Considerations
+
+### On-Device Processing
+
+All speech recognition runs locally via Apple's Speech framework. No audio data, transcripts, or scripts are sent to external servers. There are no accounts, analytics, or telemetry.
+
+### Network Servers
+
+Textream includes two optional network servers that bind to your **local network only**:
+
+| Server | Default Port | Purpose |
+|--------|-------------|---------|
+| **Remote Connection** (BrowserServer) | `8080` | Read-only teleprompter mirror for a browser |
+| **Director Mode** (DirectorServer) | `7575` / `7576` | Remote script editing via HTTP + WebSocket |
+
+**Important:**
+
+- Both servers are **disabled by default** and must be explicitly enabled in Settings.
+- Servers listen on **all local interfaces** (`0.0.0.0`). Anyone on the same network can connect when enabled.
+- There is **no authentication** on these servers. Do not enable them on untrusted or public networks.
+- The HTTP server serves a single-page web UI. The WebSocket server handles real-time communication.
+- Disable the servers when not in use.
+
+### Permissions
+
+Textream requests the following macOS permissions:
+
+- **Microphone** — Required for speech recognition and voice-activated features.
+- **Speech Recognition** — Required for on-device word tracking.
+- **Local Network** — Required when Remote Connection or Director Mode is enabled.
+
+No other permissions are requested or required.
+
+## Recommendations
+
+- Only enable network servers on trusted private networks.
+- Disable Remote Connection and Director Mode when not actively in use.
+- Keep Textream updated to the latest version via Homebrew or GitHub Releases.

--- a/Textream/Textream.xcodeproj/project.pbxproj
+++ b/Textream/Textream.xcodeproj/project.pbxproj
@@ -273,7 +273,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.6.2;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.fka.textream;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -312,7 +312,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.6.2;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.fka.textream;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;

--- a/Textream/Textream.xcodeproj/project.pbxproj
+++ b/Textream/Textream.xcodeproj/project.pbxproj
@@ -273,7 +273,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.5.2;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.fka.textream;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -312,7 +312,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.5.2;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.fka.textream;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;

--- a/Textream/Textream.xcodeproj/project.pbxproj
+++ b/Textream/Textream.xcodeproj/project.pbxproj
@@ -273,7 +273,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.5.2;
+				MARKETING_VERSION = 1.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.fka.textream;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -312,7 +312,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.5.2;
+				MARKETING_VERSION = 1.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.fka.textream;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;

--- a/Textream/Textream.xcodeproj/project.pbxproj
+++ b/Textream/Textream.xcodeproj/project.pbxproj
@@ -273,7 +273,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.fka.textream;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -312,7 +312,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.fka.textream;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;

--- a/Textream/Textream.xcodeproj/project.pbxproj
+++ b/Textream/Textream.xcodeproj/project.pbxproj
@@ -273,7 +273,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.6.2;
+				MARKETING_VERSION = 1.6.3;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.fka.textream;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -312,7 +312,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.6.2;
+				MARKETING_VERSION = 1.6.3;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.fka.textream;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;

--- a/Textream/Textream/BrowserServer.swift
+++ b/Textream/Textream/BrowserServer.swift
@@ -18,6 +18,7 @@ struct BrowserState: Codable {
     let isListening: Bool
     let isDone: Bool
     let fontColor: String
+    let cueColor: String
     let hasNextPage: Bool
     let isActive: Bool
     let highlightWords: Bool
@@ -212,6 +213,7 @@ class BrowserServer {
             isListening: speechRecognizer?.isListening ?? false,
             isDone: isDone,
             fontColor: NotchSettings.shared.fontColorPreset.cssColor,
+            cueColor: NotchSettings.shared.cueColorPreset.cssColor,
             hasNextPage: hasNextPage,
             isActive: true,
             highlightWords: highlightWords,
@@ -224,7 +226,7 @@ class BrowserServer {
         let state = BrowserState(
             words: [], highlightedCharCount: 0, totalCharCount: 0,
             audioLevels: [], isListening: false, isDone: false,
-            fontColor: "#ffffff", hasNextPage: false, isActive: false,
+            fontColor: "#ffffff", cueColor: "#ffffff", hasNextPage: false, isActive: false,
             highlightWords: true, lastSpokenText: ""
         )
         broadcast(state)
@@ -457,7 +459,9 @@ class BrowserServer {
           const c=document.getElementById('text-container'),
                 words=s.words||[],
                 fc=s.fontColor||'#ffffff',
+                cc=s.cueColor||fc,
                 rgb=parseColor(fc),
+                crgb=parseColor(cc),
                 hlWords=s.highlightWords!==false,
                 hcc=s.highlightedCharCount||0;
 
@@ -510,10 +514,10 @@ class BrowserServer {
 
             if(!hlWords){
               // Classic / silence-paused: uniform color, no per-word highlight
-              color=ann?'rgba(255,255,255,0.4)':fc;
+              color=ann?rgba(crgb,0.4):fc;
             } else if(ann){
-              // Annotation: italic, white with varying opacity
-              color=isFullyLit?'rgba(255,255,255,0.5)':'rgba(255,255,255,0.2)';
+              // Annotation: cue color with varying opacity
+              color=isFullyLit?rgba(crgb,0.5):rgba(crgb,0.2);
             } else if(isFullyLit){
               // Already read: dimmed
               color=rgba(rgb,0.3);

--- a/Textream/Textream/BrowserServer.swift
+++ b/Textream/Textream/BrowserServer.swift
@@ -201,7 +201,10 @@ class BrowserServer {
         }
 
         let effective = min(charCount, totalCharCount)
-        let isDone = totalCharCount > 0 && effective >= totalCharCount
+        let rawDone = totalCharCount > 0 && effective >= totalCharCount
+        // In classic/silence-paused modes on the last page, suppress Done so the
+        // browser keeps showing the prompter text (speaker may still be talking).
+        let isDone = rawDone && (mode == .wordTracking || hasNextPage)
 
         let highlightWords = mode == .wordTracking
 

--- a/Textream/Textream/BrowserServer.swift
+++ b/Textream/Textream/BrowserServer.swift
@@ -187,14 +187,18 @@ class BrowserServer {
 
         let charCount: Int
         let mode = NotchSettings.shared.listeningMode
+        // Check if scroll already reached the end, to stop advancing the timer
+        let scrollDone = totalCharCount > 0 && charOffsetForWordProgress(timerWordProgress) >= totalCharCount
         switch mode {
         case .wordTracking:
             charCount = speechRecognizer?.recognizedCharCount ?? 0
         case .classic:
-            timerWordProgress += NotchSettings.shared.scrollSpeed * 0.1
+            if !scrollDone {
+                timerWordProgress += NotchSettings.shared.scrollSpeed * 0.1
+            }
             charCount = charOffsetForWordProgress(timerWordProgress)
         case .silencePaused:
-            if speechRecognizer?.isListening == true && (speechRecognizer?.isSpeaking ?? false) {
+            if !scrollDone && speechRecognizer?.isListening == true && (speechRecognizer?.isSpeaking ?? false) {
                 timerWordProgress += NotchSettings.shared.scrollSpeed * 0.1
             }
             charCount = charOffsetForWordProgress(timerWordProgress)

--- a/Textream/Textream/BrowserServer.swift
+++ b/Textream/Textream/BrowserServer.swift
@@ -425,16 +425,33 @@ class BrowserServer {
         }
         function rgba(rgb,a){return 'rgba('+rgb[0]+','+rgb[1]+','+rgb[2]+','+a+')';}
 
+        // Any letter or digit, in any script. An explicit range list silently
+        // demotes every unlisted script (Hebrew, Arabic, Greek, Thai…) to an
+        // annotation, so those words render as dim cues and never highlight.
+        const WORDY=/[\\p{L}\\p{N}]/u;
+
+        // Scripts written right-to-left
+        const RTL_CHAR=/[\\p{Script=Hebrew}\\p{Script=Arabic}\\p{Script=Syriac}\\p{Script=Thaana}\\p{Script=Nko}\\p{Script=Samaritan}\\p{Script=Mandaic}\\p{Script=Adlam}]/gu;
+
         // Detect annotation words: [bracket] or emoji-only (no letters/digits)
         function isAnnotation(w){
           if(w.startsWith('[')&&w.endsWith(']'))return true;
-          return!/[a-zA-Z0-9\\u00C0-\\u024F\\u0400-\\u04FF\\u3000-\\u9FFF\\uAC00-\\uD7AF]/.test(w);
+          return!WORDY.test(w);
         }
 
         // Count letters+digits in a word
         function letterCount(w){
-          let n=0;for(const ch of w)if(/[a-zA-Z0-9\\u00C0-\\u024F\\u0400-\\u04FF\\u3000-\\u9FFF\\uAC00-\\uD7AF]/.test(ch))n++;
+          let n=0;for(const ch of w)if(WORDY.test(ch))n++;
           return Math.max(1,n);
+        }
+
+        // Base direction for the script: whichever side has more letters wins, so
+        // a Hebrew script opening with a Latin product name still reads right-to-left.
+        function baseDirection(words){
+          const s=words.join(' ');
+          const rtl=(s.match(RTL_CHAR)||[]).length;
+          const letters=(s.match(/\\p{L}/gu)||[]).length;
+          return rtl>letters-rtl?'rtl':'ltr';
         }
 
         /* ---- connection ---- */
@@ -476,6 +493,11 @@ class BrowserServer {
           const wordKey=words.length+'|'+(words[0]||'')+'|'+(words[words.length-1]||'');
           if(wordKey!==prevWordKey){
             c.innerHTML='';
+            // Let the browser's bidi engine order the line; it keeps embedded
+            // left-to-right runs (names, numbers) in reading order.
+            const dir=baseDirection(words);
+            c.setAttribute('dir',dir);
+            c.style.textAlign=dir==='rtl'?'right':'left';
             let cp=0;
             for(let i=0;i<words.length;i++){
               const wd=words[i],ann=isAnnotation(wd);

--- a/Textream/Textream/ContentView.swift
+++ b/Textream/Textream/ContentView.swift
@@ -408,15 +408,13 @@ Happy presenting! [wave]
         Group {
             if NotchSettings.shared.directorModeEnabled {
                 directorOverlay
-            } else if service.pages.count > 1 {
+            } else {
                 NavigationSplitView {
                     pageSidebar
                 } detail: {
                     mainContent
                 }
                 .navigationSplitViewColumnWidth(min: 160, ideal: 200, max: 260)
-            } else {
-                mainContent
             }
         }
         .alert(dropAlertTitle, isPresented: Binding(get: { dropError != nil }, set: { if !$0 { dropError = nil } })) {
@@ -616,7 +614,13 @@ Happy presenting! [wave]
             NSApp.windows.first?.makeKeyAndOrderFront(nil)
         }
         service.readPages.removeAll()
-        service.currentPageIndex = 0
+        // If the current page is empty, find the first non-empty page
+        let currentText = service.currentPageText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if currentText.isEmpty {
+            if let firstNonEmpty = service.pages.firstIndex(where: { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }) {
+                service.currentPageIndex = firstNonEmpty
+            }
+        }
         service.readCurrentPage()
         isRunning = true
     }

--- a/Textream/Textream/ContentView.swift
+++ b/Textream/Textream/ContentView.swift
@@ -532,10 +532,8 @@ Happy presenting! [wave]
             get: { service.currentPageIndex },
             set: { newValue in
                 if let index = newValue {
-                    DispatchQueue.main.async {
-                        withAnimation(.easeInOut(duration: 0.15)) {
-                            service.currentPageIndex = index
-                        }
+                    withAnimation(.easeInOut(duration: 0.15)) {
+                        service.currentPageIndex = index
                     }
                 }
             }

--- a/Textream/Textream/ContentView.swift
+++ b/Textream/Textream/ContentView.swift
@@ -12,7 +12,6 @@ import CoreImage.CIFilterBuiltins
 struct ContentView: View {
     @ObservedObject private var service = TextreamService.shared
     @State private var isRunning = false
-    @State private var isRecording = false
     @State private var dictation = DictationManager()
     @State private var dictationHighlightRange: NSRange? = nil
     @State private var dictationCaretPosition: Int? = nil
@@ -22,6 +21,9 @@ struct ContentView: View {
     @State private var dropAlertTitle: String = "Import Error"
     @State private var showSettings = false
     @State private var showAbout = false
+    @State private var languageSuggestion: SpeechLanguageSuggestion?
+    @State private var ignoredLanguageIdentifier: String?
+    @State private var languageDetectionTask: Task<Void, Never>?
     @FocusState private var isTextFocused: Bool
 
     private let defaultText = """
@@ -57,6 +59,89 @@ Happy presenting! [wave]
 
     private var hasAnyContent: Bool {
         service.pages.contains { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+    }
+
+    private var isRecording: Bool {
+        dictation.isRecording || dictation.isStarting
+    }
+
+    private func scheduleLanguageDetection(for text: String) {
+        languageDetectionTask?.cancel()
+        languageSuggestion = nil
+        let pageIndex = service.currentPageIndex
+        let localeIdentifier = NotchSettings.shared.speechLocale
+
+        languageDetectionTask = Task { @MainActor in
+            do {
+                try await Task.sleep(nanoseconds: 2_500_000_000)
+            } catch {
+                return
+            }
+            guard !Task.isCancelled,
+                  service.currentPageIndex == pageIndex,
+                  service.currentPageText == text,
+                  NotchSettings.shared.speechLocale == localeIdentifier else { return }
+
+            let suggestion = SpeechLanguageDetector.suggestion(
+                for: text,
+                currentLocaleIdentifier: localeIdentifier
+            )
+            guard !Task.isCancelled,
+                  suggestion?.detectedLanguageIdentifier != ignoredLanguageIdentifier else { return }
+            withAnimation(.easeInOut(duration: 0.2)) {
+                languageSuggestion = suggestion
+            }
+        }
+    }
+
+    private func languageSuggestionBanner(_ suggestion: SpeechLanguageSuggestion) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: "character.bubble.fill")
+                .foregroundStyle(Color.accentColor)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("This text looks like \(suggestion.languageName).")
+                    .font(.system(size: 12, weight: .semibold))
+                Text("Speech is currently set to \(languageLabel).")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer(minLength: 8)
+
+            Button("Use \(suggestion.languageName)") {
+                if isRecording {
+                    stopRecording()
+                }
+                ignoredLanguageIdentifier = nil
+                languageSuggestion = nil
+                NotchSettings.shared.speechLocale = suggestion.localeIdentifier
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.small)
+            .help("Switch speech recognition to \(suggestion.localeName)")
+
+            Button {
+                ignoredLanguageIdentifier = suggestion.detectedLanguageIdentifier
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    languageSuggestion = nil
+                }
+            } label: {
+                Image(systemName: "xmark")
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.secondary)
+            .help("Dismiss language suggestion")
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 9)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10))
+        .overlay {
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(Color.accentColor.opacity(0.2))
+        }
+        .padding(.horizontal, 20)
+        .padding(.top, 8)
     }
 
     @ViewBuilder
@@ -172,7 +257,6 @@ Happy presenting! [wave]
             }
         }
         dictation.start()
-        isRecording = true
     }
 
     private func stopRecording() {
@@ -182,11 +266,15 @@ Happy presenting! [wave]
         dictation.stop()
         dictation.onTextUpdate = nil
         dictation.onNewSegment = nil
-        isRecording = false
     }
 
     private var mainContent: some View {
         VStack(spacing: 0) {
+            if let languageSuggestion {
+                languageSuggestionBanner(languageSuggestion)
+                    .transition(.move(edge: .top).combined(with: .opacity))
+            }
+
             ZStack {
                 HighlightingTextEditor(
                     text: currentText,
@@ -224,7 +312,7 @@ Happy presenting! [wave]
                     Spacer()
                     ZStack {
                         // Waveform pill centered to full width
-                        if isRecording {
+                        if dictation.isRecording {
                             waveformPill
                                 .transition(.scale(scale: 0.8).combined(with: .opacity))
                         }
@@ -240,13 +328,21 @@ Happy presenting! [wave]
                                     startRecording()
                                 }
                             } label: {
-                                Image(systemName: isRecording ? "pause.fill" : "mic.fill")
-                                    .font(.system(size: 16, weight: .semibold))
-                                    .foregroundStyle(.white)
-                                    .frame(width: 44, height: 44)
-                                    .background(isRecording ? Color.orange : Color.red)
-                                    .clipShape(Circle())
-                                    .shadow(color: .black.opacity(0.2), radius: 8, y: 4)
+                                Group {
+                                    if dictation.isStarting {
+                                        ProgressView()
+                                            .controlSize(.small)
+                                            .tint(.white)
+                                    } else {
+                                        Image(systemName: isRecording ? "pause.fill" : "mic.fill")
+                                            .font(.system(size: 16, weight: .semibold))
+                                    }
+                                }
+                                .foregroundStyle(.white)
+                                .frame(width: 44, height: 44)
+                                .background(isRecording ? Color.orange : Color.red)
+                                .clipShape(Circle())
+                                .shadow(color: .black.opacity(0.2), radius: 8, y: 4)
                             }
                             .buttonStyle(.plain)
                             .disabled(isRunning)
@@ -422,12 +518,23 @@ Happy presenting! [wave]
         } message: {
             Text(dropError ?? "")
         }
+        .alert("Microphone Unavailable", isPresented: Binding(
+            get: { dictation.error != nil },
+            set: { if !$0 { dictation.error = nil } }
+        )) {
+            Button("OK") { dictation.error = nil }
+        } message: {
+            Text(dictation.error ?? "")
+        }
         .frame(minWidth: 360, minHeight: 240)
         .background(.ultraThinMaterial)
         .toolbar {
             ToolbarItem(placement: .automatic) {
                 HStack(spacing: 8) {
                     Button {
+                        if isRecording {
+                            stopRecording()
+                        }
                         service.openFile()
                     } label: {
                         HStack(spacing: 4) {
@@ -446,6 +553,9 @@ Happy presenting! [wave]
 
                     // Add page button in toolbar
                     Button {
+                        if isRecording {
+                            stopRecording()
+                        }
                         withAnimation(.easeInOut(duration: 0.2)) {
                             service.pages.append("")
                             service.currentPageIndex = service.pages.count - 1
@@ -496,6 +606,29 @@ Happy presenting! [wave]
             // Sync button state when app is re-activated (e.g. dock click)
             isRunning = service.overlayController.isShowing
         }
+        .onChange(of: service.currentPageText, initial: true) { _, text in
+            scheduleLanguageDetection(for: text)
+        }
+        .onChange(of: service.currentPageIndex) { _, _ in
+            if isRecording {
+                stopRecording()
+            }
+            ignoredLanguageIdentifier = nil
+            scheduleLanguageDetection(for: service.currentPageText)
+        }
+        .onChange(of: NotchSettings.shared.speechLocale) { _, _ in
+            if isRecording {
+                stopRecording()
+            }
+            ignoredLanguageIdentifier = nil
+            scheduleLanguageDetection(for: service.currentPageText)
+        }
+        .onDisappear {
+            languageDetectionTask?.cancel()
+            if isRecording {
+                stopRecording()
+            }
+        }
         .onAppear {
             // Set default text for the first page if empty
             if service.pages.count == 1 && service.pages[0].isEmpty {
@@ -532,6 +665,9 @@ Happy presenting! [wave]
             get: { service.currentPageIndex },
             set: { newValue in
                 if let index = newValue {
+                    if isRecording {
+                        stopRecording()
+                    }
                     withAnimation(.easeInOut(duration: 0.15)) {
                         service.currentPageIndex = index
                     }
@@ -571,6 +707,9 @@ Happy presenting! [wave]
         .listStyle(.sidebar)
         .safeAreaInset(edge: .bottom) {
             Button {
+                if isRecording {
+                    stopRecording()
+                }
                 withAnimation(.easeInOut(duration: 0.2)) {
                     service.pages.append("")
                     service.currentPageIndex = service.pages.count - 1
@@ -591,6 +730,9 @@ Happy presenting! [wave]
 
     private func removePage(at index: Int) {
         guard service.pages.count > 1 else { return }
+        if isRecording {
+            stopRecording()
+        }
         withAnimation(.easeInOut(duration: 0.2)) {
             service.pages.remove(at: index)
             if service.currentPageIndex >= service.pages.count {
@@ -627,6 +769,9 @@ Happy presenting! [wave]
 
     private func handlePresentationDrop(url: URL) {
         guard service.confirmDiscardIfNeeded() else { return }
+        if isRecording {
+            stopRecording()
+        }
         isImporting = true
 
         DispatchQueue.global(qos: .userInitiated).async {

--- a/Textream/Textream/DictationManager.swift
+++ b/Textream/Textream/DictationManager.swift
@@ -13,6 +13,7 @@ import AppKit
 @Observable
 class DictationManager {
     var isRecording: Bool = false
+    var isStarting: Bool = false
     var audioLevels: [CGFloat] = Array(repeating: 0, count: 40)
     var error: String?
 
@@ -27,68 +28,114 @@ class DictationManager {
     private var audioEngine = AVAudioEngine()
     private var configurationChangeObserver: Any?
     private var suppressConfigChange: Bool = false
+    private var pendingRestart: DispatchWorkItem?
+    private var requestLock = NSLock()
+    private var recognitionGeneration: Int = 0
+    private var shouldRecord: Bool = false
+    private var retryCount: Int = 0
+    private let maxRetries: Int = 10
 
     // Tracks the committed text from previous recognition segments
     private var committedText: String = ""
     private var sessionGeneration: Int = 0
 
     func start() {
-        guard !isRecording else { return }
+        guard !isRecording, !isStarting else { return }
         cleanup()
         committedText = ""
-        sessionGeneration += 1
+        sessionGeneration &+= 1
+        retryCount = 0
         error = nil
+        shouldRecord = true
+        isStarting = true
+        requestMicrophoneAccessAndBegin(for: sessionGeneration)
+    }
+
+    func stop() {
+        shouldRecord = false
+        sessionGeneration &+= 1
+        isRecording = false
+        isStarting = false
+        cleanup()
+    }
+
+    private func requestMicrophoneAccessAndBegin(for generation: Int) {
+        guard shouldRecord, sessionGeneration == generation else { return }
 
         // Check microphone permission
         switch AVCaptureDevice.authorizationStatus(for: .audio) {
         case .denied, .restricted:
-            error = "Microphone access denied. Open System Settings → Privacy & Security → Microphone."
-            return
+            fail("Microphone access denied. Open System Settings → Privacy & Security → Microphone.")
+            openMicrophoneSettings()
         case .notDetermined:
             AVCaptureDevice.requestAccess(for: .audio) { [weak self] granted in
                 DispatchQueue.main.async {
+                    guard let self,
+                          self.shouldRecord,
+                          self.sessionGeneration == generation else { return }
                     if granted {
-                        self?.requestSpeechAuthAndBegin()
+                        self.requestSpeechAuthAndBegin(for: generation)
                     } else {
-                        self?.error = "Microphone access denied."
+                        self.fail("Microphone access denied. Open System Settings → Privacy & Security → Microphone.")
                     }
                 }
             }
-            return
         case .authorized:
-            break
+            requestSpeechAuthAndBegin(for: generation)
         @unknown default:
-            break
+            fail("Microphone authorization is unavailable.")
         }
-
-        requestSpeechAuthAndBegin()
     }
 
-    func stop() {
-        isRecording = false
-        cleanup()
-    }
-
-    private func requestSpeechAuthAndBegin() {
+    private func requestSpeechAuthAndBegin(for generation: Int) {
         SFSpeechRecognizer.requestAuthorization { [weak self] status in
             DispatchQueue.main.async {
+                guard let self,
+                      self.shouldRecord,
+                      self.sessionGeneration == generation else { return }
                 switch status {
                 case .authorized:
-                    self?.beginRecognition()
+                    self.beginRecognition()
                 default:
-                    self?.error = "Speech recognition not authorized."
+                    self.fail("Speech recognition not authorized. Open System Settings → Privacy & Security → Speech Recognition.")
+                    self.openSpeechRecognitionSettings()
                 }
             }
         }
     }
 
+    private func openMicrophoneSettings() {
+        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone") {
+            NSWorkspace.shared.open(url)
+        }
+    }
+
+    private func openSpeechRecognitionSettings() {
+        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_SpeechRecognition") {
+            NSWorkspace.shared.open(url)
+        }
+    }
+
+    private func fail(_ message: String) {
+        shouldRecord = false
+        isRecording = false
+        isStarting = false
+        error = message
+        cleanup()
+    }
+
     private func cleanup() {
+        recognitionGeneration &+= 1
+        pendingRestart?.cancel()
+        pendingRestart = nil
         if let observer = configurationChangeObserver {
             NotificationCenter.default.removeObserver(observer)
             configurationChangeObserver = nil
         }
+        requestLock.lock()
         recognitionRequest?.endAudio()
         recognitionRequest = nil
+        requestLock.unlock()
         recognitionTask?.cancel()
         recognitionTask = nil
         if audioEngine.isRunning {
@@ -98,9 +145,13 @@ class DictationManager {
     }
 
     private func beginRecognition() {
+        guard shouldRecord else { return }
+        let expectedSessionGeneration = sessionGeneration
         cleanup()
+        guard shouldRecord, sessionGeneration == expectedSessionGeneration else { return }
 
         audioEngine = AVAudioEngine()
+        suppressConfigChange = false
 
         // Set selected microphone if configured
         let micUID = NotchSettings.shared.selectedMicUID
@@ -120,27 +171,55 @@ class DictationManager {
                 AudioUnitInitialize(audioUnit)
             }
             DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
-                self?.suppressConfigChange = false
+                guard let self,
+                      self.sessionGeneration == expectedSessionGeneration else { return }
+                self.suppressConfigChange = false
             }
         }
 
         speechRecognizer = SFSpeechRecognizer(locale: Locale(identifier: NotchSettings.shared.speechLocale))
-        guard let speechRecognizer, speechRecognizer.isAvailable else {
-            error = "Speech recognizer not available"
+        guard let speechRecognizer else {
+            fail("Speech recognition isn't supported for the selected language.")
+            return
+        }
+        guard speechRecognizer.isAvailable else {
+            if retryCount < maxRetries {
+                retryCount += 1
+                scheduleRestart(after: 0.5)
+            } else {
+                fail("Speech recognizer is not available.")
+            }
             return
         }
 
         recognitionRequest = SFSpeechAudioBufferRecognitionRequest()
-        guard let recognitionRequest else { return }
+        guard let recognitionRequest else {
+            fail("Unable to create a speech recognition request.")
+            return
+        }
         recognitionRequest.shouldReportPartialResults = true
+        recognitionRequest.taskHint = .dictation
 
         let inputNode = audioEngine.inputNode
         let recordingFormat = inputNode.outputFormat(forBus: 0)
 
         guard recordingFormat.sampleRate > 0, recordingFormat.channelCount > 0 else {
-            error = "Audio input unavailable"
+            if retryCount < maxRetries {
+                retryCount += 1
+                scheduleRestart(after: 0.5)
+            } else {
+                fail("Audio input is unavailable.")
+            }
             return
         }
+
+        let monoFormat = AVAudioFormat(
+            commonFormat: recordingFormat.commonFormat,
+            sampleRate: recordingFormat.sampleRate,
+            channels: 1,
+            interleaved: recordingFormat.isInterleaved
+        )
+        let tapFormat = recordingFormat.channelCount > 1 ? monoFormat : recordingFormat
 
         // Observe audio configuration changes
         configurationChangeObserver = NotificationCenter.default.addObserver(
@@ -148,14 +227,16 @@ class DictationManager {
             object: audioEngine,
             queue: .main
         ) { [weak self] _ in
-            guard let self, !self.suppressConfigChange, self.isRecording else { return }
+            guard let self,
+                  self.shouldRecord,
+                  !self.suppressConfigChange else { return }
             self.restartRecognition()
         }
 
         inputNode.removeTap(onBus: 0)
 
-        inputNode.installTap(onBus: 0, bufferSize: 1024, format: nil) { [weak self] buffer, _ in
-            recognitionRequest.append(buffer)
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: tapFormat) { [weak self] buffer, _ in
+            self?.appendBuffer(buffer)
 
             guard let channelData = buffer.floatChannelData?[0] else { return }
             let frameLength = Int(buffer.frameLength)
@@ -174,22 +255,29 @@ class DictationManager {
             }
         }
 
-        // Notify that a new recognition segment is starting
-        onNewSegment?()
-
+        recognitionGeneration &+= 1
+        let currentRecognitionGeneration = recognitionGeneration
         let currentGeneration = sessionGeneration
         recognitionTask = speechRecognizer.recognitionTask(with: recognitionRequest) { [weak self] result, error in
             guard let self else { return }
             if let result {
                 let spoken = result.bestTranscription.formattedString
                 DispatchQueue.main.async {
-                    guard self.sessionGeneration == currentGeneration else { return }
+                    guard self.sessionGeneration == currentGeneration,
+                          self.recognitionGeneration == currentRecognitionGeneration else { return }
+                    self.retryCount = 0
                     self.onTextUpdate?(spoken)
+                    if result.isFinal {
+                        self.restartRecognition()
+                    }
                 }
             }
             if error != nil {
                 DispatchQueue.main.async {
-                    guard self.recognitionRequest != nil, self.isRecording else { return }
+                    guard self.sessionGeneration == currentGeneration,
+                          self.recognitionGeneration == currentRecognitionGeneration,
+                          self.recognitionRequest != nil,
+                          self.shouldRecord else { return }
                     self.restartRecognition()
                 }
             }
@@ -198,19 +286,51 @@ class DictationManager {
         do {
             audioEngine.prepare()
             try audioEngine.start()
+            guard shouldRecord, sessionGeneration == expectedSessionGeneration else {
+                cleanup()
+                return
+            }
+            retryCount = 0
+            error = nil
+            isStarting = false
             isRecording = true
+            // Notify that a new recognition segment is starting
+            onNewSegment?()
         } catch {
-            self.error = "Audio engine failed: \(error.localizedDescription)"
-            isRecording = false
+            if retryCount < maxRetries {
+                retryCount += 1
+                scheduleRestart(after: 0.5)
+            } else {
+                fail("Audio engine failed: \(error.localizedDescription)")
+            }
         }
     }
 
+    private func appendBuffer(_ buffer: AVAudioPCMBuffer) {
+        requestLock.lock()
+        recognitionRequest?.append(buffer)
+        requestLock.unlock()
+    }
+
     private func restartRecognition() {
-        guard isRecording else { return }
+        guard shouldRecord else { return }
+        isRecording = false
+        isStarting = true
         cleanup()
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
-            guard let self, self.isRecording else { return }
+        scheduleRestart(after: 0.3)
+    }
+
+    private func scheduleRestart(after delay: TimeInterval) {
+        pendingRestart?.cancel()
+        let expectedSessionGeneration = sessionGeneration
+        let work = DispatchWorkItem { [weak self] in
+            guard let self,
+                  self.shouldRecord,
+                  self.sessionGeneration == expectedSessionGeneration else { return }
+            self.pendingRestart = nil
             self.beginRecognition()
         }
+        pendingRestart = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: work)
     }
 }

--- a/Textream/Textream/DirectorServer.swift
+++ b/Textream/Textream/DirectorServer.swift
@@ -295,7 +295,8 @@ class DirectorServer {
         if let last = lastBroadcastState, last == data { return }
         lastBroadcastState = data
 
-        let connections = wsConnections
+        let connections = wsConnections.filter { authenticatedConnections.contains(ObjectIdentifier($0)) }
+        guard !connections.isEmpty else { return }
         let meta = NWProtocolWebSocket.Metadata(opcode: .text)
         let ctx = NWConnection.ContentContext(identifier: "ws", metadata: [meta])
 

--- a/Textream/Textream/DirectorServer.swift
+++ b/Textream/Textream/DirectorServer.swift
@@ -18,6 +18,7 @@ struct DirectorState: Codable {
     let isDone: Bool
     let isListening: Bool
     let fontColor: String
+    let cueColor: String
     let lastSpokenText: String
     let audioLevels: [Double]
 }
@@ -272,6 +273,7 @@ class DirectorServer {
             isDone: isDone,
             isListening: speechRecognizer?.isListening ?? false,
             fontColor: NotchSettings.shared.fontColorPreset.cssColor,
+            cueColor: NotchSettings.shared.cueColorPreset.cssColor,
             lastSpokenText: speechRecognizer?.lastSpokenText ?? "",
             audioLevels: (speechRecognizer?.audioLevels ?? []).map { Double($0) }
         )
@@ -282,7 +284,7 @@ class DirectorServer {
         let state = DirectorState(
             words: [], highlightedCharCount: 0, totalCharCount: 0,
             isActive: false, isDone: false, isListening: false,
-            fontColor: "#ffffff", lastSpokenText: "",
+            fontColor: "#ffffff", cueColor: "#ffffff", lastSpokenText: "",
             audioLevels: []
         )
         broadcast(state)

--- a/Textream/Textream/DirectorServer.swift
+++ b/Textream/Textream/DirectorServer.swift
@@ -419,9 +419,9 @@ class DirectorServer {
 
         <div id="editor-wrap">
           <div id="editor-container">
-            <div id="read-text"></div>
+            <div id="read-text" dir="auto"></div>
             <div id="read-divider"></div>
-            <div id="edit-text" contenteditable="true" data-placeholder="Type or paste your script here…" spellcheck="false"></div>
+            <div id="edit-text" dir="auto" contenteditable="true" data-placeholder="Type or paste your script here…" spellcheck="false"></div>
           </div>
         </div>
 

--- a/Textream/Textream/ExternalDisplayController.swift
+++ b/Textream/Textream/ExternalDisplayController.swift
@@ -225,6 +225,9 @@ struct ExternalDisplayView: View {
                     highlightedCharCount: effectiveCharCount,
                     font: .systemFont(ofSize: fontSize, weight: .semibold),
                     highlightColor: NotchSettings.shared.fontColorPreset.color,
+                    cueColor: NotchSettings.shared.cueColorPreset.color,
+                    cueUnreadOpacity: NotchSettings.shared.cueBrightness.unreadOpacity,
+                    cueReadOpacity: NotchSettings.shared.cueBrightness.readOpacity,
                     onWordTap: { charOffset in
                         if listeningMode == .wordTracking {
                             speechRecognizer.jumpTo(charOffset: charOffset)

--- a/Textream/Textream/ExternalDisplayController.swift
+++ b/Textream/Textream/ExternalDisplayController.swift
@@ -176,7 +176,7 @@ struct ExternalDisplayView: View {
         ZStack {
             Color.black.ignoresSafeArea()
 
-            if isDone {
+            if isDone && (listeningMode == .wordTracking || hasNextPage) {
                 doneView
             } else {
                 prompterView
@@ -192,7 +192,7 @@ struct ExternalDisplayView: View {
         .scaleEffect(x: mirrorAxis?.scaleX ?? 1, y: mirrorAxis?.scaleY ?? 1)
         .animation(.easeInOut(duration: 0.5), value: isDone)
         .onChange(of: isDone) { _, done in
-            if done {
+            if done && listeningMode == .wordTracking {
                 speechRecognizer.stop()
             }
         }

--- a/Textream/Textream/HighlightingTextEditor.swift
+++ b/Textream/Textream/HighlightingTextEditor.swift
@@ -62,8 +62,6 @@ struct HighlightingTextEditor: NSViewRepresentable {
         textView.string = text
         context.coordinator.applyHighlighting(textView)
 
-        updateWritingDirection(textView, text: text)
-
         return scrollView
     }
 
@@ -76,7 +74,6 @@ struct HighlightingTextEditor: NSViewRepresentable {
             textView.selectedRanges = selectedRanges
             context.coordinator.applyHighlighting(textView)
         }
-        updateWritingDirection(textView, text: text)
 
         // Apply bump highlight on newly dictated range
         if let range = highlightRange, range.location + range.length <= textView.string.count {
@@ -94,16 +91,32 @@ struct HighlightingTextEditor: NSViewRepresentable {
         }
     }
 
-    /// Set the text view's base writing direction based on the content's script.
-    private func updateWritingDirection(_ textView: NSTextView, text: String) {
-        switch textBaseDirection(in: text) {
+    /// Sets the text view's base writing direction from the content's script and
+    /// returns the matching paragraph style.
+    ///
+    /// The style has to be re-applied as part of highlighting: `applyHighlighting`
+    /// resets every attribute over the full range, so a paragraph style set only
+    /// here is wiped on the next keystroke and the text jumps back to left-aligned.
+    @discardableResult
+    fileprivate func updateWritingDirection(_ textView: NSTextView, text: String) -> NSParagraphStyle {
+        let direction = dominantBaseDirection(in: text)
+
+        let style = NSMutableParagraphStyle()
+        switch direction {
         case .rightToLeft:
             textView.baseWritingDirection = .rightToLeft
+            style.baseWritingDirection = .rightToLeft
+            style.alignment = .right
         case .leftToRight:
             textView.baseWritingDirection = .leftToRight
+            style.baseWritingDirection = .leftToRight
+            style.alignment = .left
         case .natural:
             textView.baseWritingDirection = .natural
+            style.baseWritingDirection = .natural
+            style.alignment = .natural
         }
+        return style
     }
 
     class Coordinator: NSObject, NSTextViewDelegate {
@@ -122,7 +135,6 @@ struct HighlightingTextEditor: NSViewRepresentable {
         func textDidChange(_ notification: Notification) {
             guard let textView = notification.object as? NSTextView else { return }
             parent.text = textView.string
-            parent.updateWritingDirection(textView, text: textView.string)
             applyHighlighting(textView)
         }
 
@@ -163,12 +175,17 @@ struct HighlightingTextEditor: NSViewRepresentable {
             // Preserve selection
             let selectedRanges = textView.selectedRanges
 
+            // Resolve the writing direction before editing so the paragraph style
+            // survives the attribute reset below.
+            let paragraphStyle = parent.updateWritingDirection(textView, text: text)
+
             textStorage.beginEditing()
 
             // Reset to default style
             let defaultAttributes: [NSAttributedString.Key: Any] = [
                 .font: parent.font,
-                .foregroundColor: NSColor.labelColor
+                .foregroundColor: NSColor.labelColor,
+                .paragraphStyle: paragraphStyle
             ]
             textStorage.setAttributes(defaultAttributes, range: fullRange)
 
@@ -184,6 +201,10 @@ struct HighlightingTextEditor: NSViewRepresentable {
             }
 
             textStorage.endEditing()
+
+            // Keep newly typed text in the same direction as the rest of the page
+            textView.defaultParagraphStyle = paragraphStyle
+            textView.typingAttributes = defaultAttributes
 
             // Restore selection
             textView.selectedRanges = selectedRanges

--- a/Textream/Textream/HighlightingTextEditor.swift
+++ b/Textream/Textream/HighlightingTextEditor.swift
@@ -62,6 +62,8 @@ struct HighlightingTextEditor: NSViewRepresentable {
         textView.string = text
         context.coordinator.applyHighlighting(textView)
 
+        updateWritingDirection(textView, text: text)
+
         return scrollView
     }
 
@@ -74,6 +76,7 @@ struct HighlightingTextEditor: NSViewRepresentable {
             textView.selectedRanges = selectedRanges
             context.coordinator.applyHighlighting(textView)
         }
+        updateWritingDirection(textView, text: text)
 
         // Apply bump highlight on newly dictated range
         if let range = highlightRange, range.location + range.length <= textView.string.count {
@@ -88,6 +91,18 @@ struct HighlightingTextEditor: NSViewRepresentable {
             DispatchQueue.main.async {
                 self.caretPosition = nil
             }
+        }
+    }
+
+    /// Set the text view's base writing direction based on the content's script.
+    private func updateWritingDirection(_ textView: NSTextView, text: String) {
+        switch textBaseDirection(in: text) {
+        case .rightToLeft:
+            textView.baseWritingDirection = .rightToLeft
+        case .leftToRight:
+            textView.baseWritingDirection = .leftToRight
+        case .natural:
+            textView.baseWritingDirection = .natural
         }
     }
 
@@ -107,6 +122,7 @@ struct HighlightingTextEditor: NSViewRepresentable {
         func textDidChange(_ notification: Notification) {
             guard let textView = notification.object as? NSTextView else { return }
             parent.text = textView.string
+            parent.updateWritingDirection(textView, text: textView.string)
             applyHighlighting(textView)
         }
 

--- a/Textream/Textream/LanguageDetection.swift
+++ b/Textream/Textream/LanguageDetection.swift
@@ -1,0 +1,137 @@
+import Foundation
+import NaturalLanguage
+import Speech
+
+struct SpeechLanguageSuggestion: Equatable {
+    let detectedLanguageIdentifier: String
+    let languageCode: String
+    let localeIdentifier: String
+    let confidence: Double
+
+    var languageName: String {
+        Locale.current.localizedString(forIdentifier: detectedLanguageIdentifier)
+            ?? Locale.current.localizedString(forLanguageCode: languageCode)
+            ?? detectedLanguageIdentifier
+    }
+
+    var localeName: String {
+        Locale.current.localizedString(forIdentifier: localeIdentifier) ?? languageName
+    }
+}
+
+enum SpeechLocaleSupport {
+    static let supportedLocales = SFSpeechRecognizer.supportedLocales()
+        .sorted { $0.identifier < $1.identifier }
+
+    static func closestSupportedLocale(to identifier: String) -> Locale? {
+        let normalizedIdentifier = normalized(identifier)
+        if let exact = supportedLocales.first(where: { normalized($0.identifier) == normalizedIdentifier }) {
+            return exact
+        }
+
+        let locale = Locale(identifier: identifier)
+        guard let languageCode = locale.language.languageCode?.identifier else { return nil }
+        return closestSupportedLocale(
+            for: Locale.Language(identifier: languageCode),
+            preferredRegion: locale.region ?? Locale.current.region
+        )
+    }
+
+    static func closestSupportedLocale(
+        for language: Locale.Language,
+        preferredRegion: Locale.Region? = Locale.current.region
+    ) -> Locale? {
+        guard let languageCode = language.languageCode?.identifier else { return nil }
+        let candidates = supportedLocales.filter {
+            $0.language.languageCode?.identifier == languageCode
+        }
+        guard !candidates.isEmpty else { return nil }
+
+        let target = Locale.Language(identifier: language.maximalIdentifier)
+        return candidates.sorted { lhs, rhs in
+            let lhsScore = score(lhs, target: target, preferredRegion: preferredRegion)
+            let rhsScore = score(rhs, target: target, preferredRegion: preferredRegion)
+            if lhsScore == rhsScore {
+                return lhs.identifier < rhs.identifier
+            }
+            return lhsScore > rhsScore
+        }.first
+    }
+
+    static func matches(language: Locale.Language, localeIdentifier: String) -> Bool {
+        let selected = Locale.Language(identifier: localeIdentifier)
+        guard language.languageCode?.identifier == selected.languageCode?.identifier else {
+            return false
+        }
+
+        let detectedScript = Locale.Language(identifier: language.maximalIdentifier).script?.identifier
+        let selectedScript = Locale.Language(identifier: selected.maximalIdentifier).script?.identifier
+        return detectedScript == nil || selectedScript == nil || detectedScript == selectedScript
+    }
+
+    private static func score(
+        _ locale: Locale,
+        target: Locale.Language,
+        preferredRegion: Locale.Region?
+    ) -> Int {
+        let candidate = Locale.Language(identifier: locale.language.maximalIdentifier)
+        var result = 0
+
+        if candidate.script?.identifier == target.script?.identifier {
+            result += 200
+        }
+        if let preferredRegion,
+           locale.region?.identifier == preferredRegion.identifier {
+            result += 100
+        }
+        if candidate.region?.identifier == target.region?.identifier {
+            result += 50
+        }
+        return result
+    }
+
+    private static func normalized(_ identifier: String) -> String {
+        identifier.replacingOccurrences(of: "_", with: "-").lowercased()
+    }
+}
+
+enum SpeechLanguageDetector {
+    static func suggestion(
+        for text: String,
+        currentLocaleIdentifier: String
+    ) -> SpeechLanguageSuggestion? {
+        let scrubbed = text.replacingOccurrences(
+            of: "\\[[^\\]]*\\]",
+            with: " ",
+            options: .regularExpression
+        )
+        let sample = String(scrubbed.prefix(6_000))
+        guard sample.lazy.filter(\.isLetter).prefix(20).count == 20 else { return nil }
+
+        let recognizer = NLLanguageRecognizer()
+        recognizer.processString(sample)
+        guard let dominantLanguage = recognizer.dominantLanguage,
+              dominantLanguage != .undetermined,
+              let confidence = recognizer.languageHypotheses(withMaximum: 3)[dominantLanguage],
+              confidence >= 0.75 else {
+            return nil
+        }
+
+        let detectedLanguage = Locale.Language(identifier: dominantLanguage.rawValue)
+        guard !SpeechLocaleSupport.matches(
+            language: detectedLanguage,
+            localeIdentifier: currentLocaleIdentifier
+        ),
+        let languageCode = detectedLanguage.languageCode?.identifier,
+        let locale = SpeechLocaleSupport.closestSupportedLocale(for: detectedLanguage) else {
+            return nil
+        }
+
+        return SpeechLanguageSuggestion(
+            detectedLanguageIdentifier: dominantLanguage.rawValue,
+            languageCode: languageCode,
+            localeIdentifier: locale.identifier,
+            confidence: confidence
+        )
+    }
+}

--- a/Textream/Textream/MarqueeTextView.swift
+++ b/Textream/Textream/MarqueeTextView.swift
@@ -81,6 +81,9 @@ struct SpeechScrollView: View {
     let highlightedCharCount: Int
     var font: NSFont = .systemFont(ofSize: 18, weight: .semibold)
     var highlightColor: Color = .white
+    var cueColor: Color = .white
+    var cueUnreadOpacity: Double = 0.2
+    var cueReadOpacity: Double = 0.5
     var onWordTap: ((Int) -> Void)? = nil
     /// Called when user starts/stops manual scrolling in smooth mode.
     /// Bool: true = scrolling started (pause timer), false = scrolling ended (resume timer).
@@ -104,6 +107,9 @@ struct SpeechScrollView: View {
                 highlightedCharCount: highlightedCharCount,
                 font: font,
                 highlightColor: highlightColor,
+                cueColor: cueColor,
+                cueUnreadOpacity: cueUnreadOpacity,
+                cueReadOpacity: cueReadOpacity,
                 highlightWords: !smoothScroll,
                 containerWidth: geo.size.width,
                 onWordTap: { charOffset in
@@ -328,6 +334,9 @@ struct WordFlowLayout: View {
     let highlightedCharCount: Int
     let font: NSFont
     var highlightColor: Color = .white
+    var cueColor: Color = .white
+    var cueUnreadOpacity: Double = 0.2
+    var cueReadOpacity: Double = 0.5
     var highlightWords: Bool = true
     let containerWidth: CGFloat
     var onWordTap: ((Int) -> Void)? = nil
@@ -422,7 +431,7 @@ struct WordFlowLayout: View {
         // When highlighting is off (classic/silence-paused), use uniform color
         if !highlightWords {
             let uniformColor: Color = item.isAnnotation
-                ? Color.white.opacity(0.4)
+                ? cueColor.opacity(cueUnreadOpacity)
                 : highlightColor
 
             return Text(item.word + " ")
@@ -442,11 +451,11 @@ struct WordFlowLayout: View {
                 }
         }
 
-        // Annotations: italic, always dimmed
+        // Annotations: italic, dimmed with cue color
         if item.isAnnotation {
             let annotationColor: Color = isFullyLit
-                ? Color.white.opacity(0.5)
-                : Color.white.opacity(0.2)
+                ? cueColor.opacity(cueReadOpacity)
+                : cueColor.opacity(cueUnreadOpacity)
 
             return Text(item.word + " ")
                 .font(Font(font).italic())

--- a/Textream/Textream/MarqueeTextView.swift
+++ b/Textream/Textream/MarqueeTextView.swift
@@ -503,8 +503,9 @@ struct WordFlowLayout: View {
     private func buildItems() -> [WordItem] {
         var items: [WordItem] = []
         var offset = 0
+        let annotationFlags = SpeechTextAlignment.annotationFlags(for: words)
         for (i, word) in words.enumerated() {
-            let isAnnotation = Self.isAnnotationWord(word)
+            let isAnnotation = annotationFlags[i] || Self.isAnnotationWord(word)
             items.append(WordItem(id: i, word: word, charOffset: offset, isAnnotation: isAnnotation))
             offset += word.count + 1 // +1 for space
         }

--- a/Textream/Textream/MarqueeTextView.swift
+++ b/Textream/Textream/MarqueeTextView.swift
@@ -352,22 +352,34 @@ struct WordFlowLayout: View {
         return ratio > 1.5 ? 2 : 8
     }
 
+    /// Width of the gap rendered between two words on a line.
+    private var spaceWidth: CGFloat {
+        (" " as NSString).size(withAttributes: [.font: font]).width
+    }
+
     // Simple layout cache to avoid re-measuring words on every highlight update
     private static var _cacheKey: String = ""
     private static var _cachedItems: [WordItem] = []
-    private static var _cachedLines: [[WordItem]] = []
+    private static var _cachedLines: [[BidiOrderedWord<WordItem>]] = []
+    private static var _cachedIsRTL: Bool = false
 
-    private func cachedLayout() -> ([WordItem], [[WordItem]]) {
+    private func cachedLayout() -> ([WordItem], [[BidiOrderedWord<WordItem>]], Bool) {
         let key = "\(words.count)|\(words.first ?? "")|\(words.last ?? "")|\(font.pointSize)|\(Int(containerWidth))"
         if key == Self._cacheKey {
-            return (Self._cachedItems, Self._cachedLines)
+            return (Self._cachedItems, Self._cachedLines, Self._cachedIsRTL)
         }
         let items = buildItems()
-        let lines = buildLines(items: items)
+        let rtl = isRightToLeft(items: items)
+        // Reorder each line once here rather than per redraw — the visual order
+        // only changes when the words or the wrap width change.
+        let lines = buildLines(items: items).map { line in
+            bidiVisualOrder(line, baseIsRightToLeft: rtl) { wordDirectionClass($0.word) }
+        }
         Self._cacheKey = key
         Self._cachedItems = items
         Self._cachedLines = lines
-        return (items, lines)
+        Self._cachedIsRTL = rtl
+        return (items, lines, rtl)
     }
 
     // Find the index of the next word to read (first non-fully-lit, non-annotation word)
@@ -384,25 +396,28 @@ struct WordFlowLayout: View {
         return -1
     }
 
+    /// Base direction for the page, taken from whichever script dominates the
+    /// script's own words. Cues like `[pause]` are excluded so an English cue
+    /// can't flip a Hebrew script left-to-right.
     private func isRightToLeft(items: [WordItem]) -> Bool {
+        var rightToLeftCount = 0
+        var leftToRightCount = 0
+
         for item in items where !item.isAnnotation {
-            switch textBaseDirection(in: item.word) {
-            case .rightToLeft:
-                return true
-            case .leftToRight:
-                return false
-            case .natural:
-                continue
+            switch wordDirectionClass(item.word) {
+            case .rightToLeft: rightToLeftCount += 1
+            case .leftToRight: leftToRightCount += 1
+            case .neutral: continue
             }
         }
-        return false
+
+        return rightToLeftCount > leftToRightCount
     }
 
     var body: some View {
-        let (items, lines) = cachedLayout()
+        let (items, lines, rtl) = cachedLayout()
         let nextIdx = nextWordIndex(items: items)
         let totalLines = lines.count
-        let rtl = isRightToLeft(items: items)
 
         // Estimate line height for visibility culling using actual font metrics
         let lineH = ceil(font.ascender - font.descender + font.leading) + lineSpacing
@@ -413,21 +428,28 @@ struct WordFlowLayout: View {
         let startLine = canCull ? max(0, min(totalLines, Int(floor((-scrollOffset - buffer) / lineH)))) : 0
         let endLine = canCull ? max(startLine, min(totalLines, Int(ceil((viewportHeight - scrollOffset + buffer) / lineH)))) : totalLines
 
-        // For RTL scripts (Arabic, Hebrew, Persian, Urdu), flip the layout direction
-        // so words within each line flow right-to-left instead of left-to-right.
+        // For RTL scripts (Arabic, Hebrew, Persian, Urdu) each line is pre-ordered
+        // into visual order by `cachedLayout`, so the stack itself always runs
+        // left-to-right and only the page alignment flips.
         VStack(alignment: rtl ? .trailing : .leading, spacing: lineSpacing) {
             if startLine > 0 {
                 Color.clear.frame(height: CGFloat(startLine) * lineH)
             }
 
             ForEach(startLine..<endLine, id: \.self) { lineIdx in
-                HStack(spacing: 0) {
-                    ForEach(lines[lineIdx], id: \.id) { item in
-                        wordView(for: item, isNextWord: item.id == nextIdx)
-                            .id(item.id)
+                // Words are spaced by the stack rather than by a trailing space in
+                // each `Text`: text layout trims trailing whitespace, which in RTL
+                // collapses every gap and runs the whole line together.
+                HStack(spacing: spaceWidth) {
+                    ForEach(lines[lineIdx], id: \.element.id) { ordered in
+                        wordView(
+                            for: ordered.element,
+                            isNextWord: ordered.element.id == nextIdx,
+                            isRightToLeft: ordered.isRightToLeft
+                        )
+                        .id(ordered.element.id)
                     }
                 }
-                .environment(\.layoutDirection, rtl ? .rightToLeft : .leftToRight)
             }
 
             if endLine < totalLines {
@@ -438,13 +460,14 @@ struct WordFlowLayout: View {
         .coordinateSpace(name: "flowLayout")
     }
 
-    private func wordView(for item: WordItem, isNextWord: Bool) -> some View {
+    private func wordView(for item: WordItem, isNextWord: Bool, isRightToLeft: Bool) -> some View {
         let wordLen = item.word.count
         let charsIntoWord = highlightedCharCount - item.charOffset
         let litCount = max(0, min(wordLen, charsIntoWord))
         let letterCount = max(1, item.word.filter { $0.isLetter || $0.isNumber }.count)
         let isFullyLit = litCount >= letterCount
         let isCurrentWord = isNextWord || (charsIntoWord >= 0 && !isFullyLit)
+        let display = directionIsolated(item.word, isRightToLeft: isRightToLeft)
 
         // When highlighting is off (classic/silence-paused), use uniform color
         if !highlightWords {
@@ -452,7 +475,7 @@ struct WordFlowLayout: View {
                 ? cueColor.opacity(cueUnreadOpacity)
                 : highlightColor
 
-            return Text(item.word + " ")
+            return Text(display)
                 .font(item.isAnnotation ? Font(font).italic() : Font(font))
                 .foregroundStyle(uniformColor)
                 .background(
@@ -475,7 +498,7 @@ struct WordFlowLayout: View {
                 ? cueColor.opacity(cueReadOpacity)
                 : cueColor.opacity(cueUnreadOpacity)
 
-            return Text(item.word + " ")
+            return Text(display)
                 .font(Font(font).italic())
                 .foregroundStyle(annotationColor)
                 .background(
@@ -500,7 +523,7 @@ struct WordFlowLayout: View {
         // Base color for the whole word
         let wordColor: Color = isFullyLit ? highlightColor.opacity(0.3) : dimColor
 
-        return Text(item.word + " ")
+        return Text(display)
             .font(Font(font))
             .foregroundStyle(wordColor)
             .underline(isCurrentWord, color: wordColor)

--- a/Textream/Textream/MarqueeTextView.swift
+++ b/Textream/Textream/MarqueeTextView.swift
@@ -384,10 +384,25 @@ struct WordFlowLayout: View {
         return -1
     }
 
+    private func isRightToLeft(items: [WordItem]) -> Bool {
+        for item in items where !item.isAnnotation {
+            switch textBaseDirection(in: item.word) {
+            case .rightToLeft:
+                return true
+            case .leftToRight:
+                return false
+            case .natural:
+                continue
+            }
+        }
+        return false
+    }
+
     var body: some View {
         let (items, lines) = cachedLayout()
         let nextIdx = nextWordIndex(items: items)
         let totalLines = lines.count
+        let rtl = isRightToLeft(items: items)
 
         // Estimate line height for visibility culling using actual font metrics
         let lineH = ceil(font.ascender - font.descender + font.leading) + lineSpacing
@@ -398,7 +413,9 @@ struct WordFlowLayout: View {
         let startLine = canCull ? max(0, min(totalLines, Int(floor((-scrollOffset - buffer) / lineH)))) : 0
         let endLine = canCull ? max(startLine, min(totalLines, Int(ceil((viewportHeight - scrollOffset + buffer) / lineH)))) : totalLines
 
-        VStack(alignment: .leading, spacing: lineSpacing) {
+        // For RTL scripts (Arabic, Hebrew, Persian, Urdu), flip the layout direction
+        // so words within each line flow right-to-left instead of left-to-right.
+        VStack(alignment: rtl ? .trailing : .leading, spacing: lineSpacing) {
             if startLine > 0 {
                 Color.clear.frame(height: CGFloat(startLine) * lineH)
             }
@@ -410,13 +427,14 @@ struct WordFlowLayout: View {
                             .id(item.id)
                     }
                 }
+                .environment(\.layoutDirection, rtl ? .rightToLeft : .leftToRight)
             }
 
             if endLine < totalLines {
                 Color.clear.frame(height: CGFloat(totalLines - endLine) * lineH)
             }
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
+        .frame(maxWidth: .infinity, alignment: rtl ? .trailing : .leading)
         .coordinateSpace(name: "flowLayout")
     }
 

--- a/Textream/Textream/NotchOverlayController.swift
+++ b/Textream/Textream/NotchOverlayController.swift
@@ -823,6 +823,9 @@ struct NotchOverlayView: View {
                 highlightedCharCount: effectiveCharCount,
                 font: NotchSettings.shared.font,
                 highlightColor: NotchSettings.shared.fontColorPreset.color,
+                cueColor: NotchSettings.shared.cueColorPreset.color,
+                cueUnreadOpacity: NotchSettings.shared.cueBrightness.unreadOpacity,
+                cueReadOpacity: NotchSettings.shared.cueBrightness.readOpacity,
                 onWordTap: { charOffset in
                     if listeningMode == .wordTracking {
                         speechRecognizer.jumpTo(charOffset: charOffset)
@@ -1298,6 +1301,9 @@ struct FloatingOverlayView: View {
                 highlightedCharCount: effectiveCharCount,
                 font: NotchSettings.shared.font,
                 highlightColor: NotchSettings.shared.fontColorPreset.color,
+                cueColor: NotchSettings.shared.cueColorPreset.color,
+                cueUnreadOpacity: NotchSettings.shared.cueBrightness.unreadOpacity,
+                cueReadOpacity: NotchSettings.shared.cueBrightness.readOpacity,
                 onWordTap: { charOffset in
                     if listeningMode == .wordTracking {
                         speechRecognizer.jumpTo(charOffset: charOffset)

--- a/Textream/Textream/NotchOverlayController.swift
+++ b/Textream/Textream/NotchOverlayController.swift
@@ -721,7 +721,7 @@ struct NotchOverlayView: View {
 
                         if content.showPagePicker {
                             pagePickerView
-                        } else if isDone {
+                        } else if isDone && (listeningMode == .wordTracking || hasNextPage) {
                             doneView
                         } else {
                             prompterView
@@ -765,12 +765,19 @@ struct NotchOverlayView: View {
         .animation(.easeInOut(duration: 0.5), value: isDone)
         .onChange(of: isDone) { _, done in
             if done {
-                // Stop listening when page is done
-                speechRecognizer.stop()
+                // In word tracking mode, stop listening when page is done
+                if listeningMode == .wordTracking {
+                    speechRecognizer.stop()
+                }
                 if !hasNextPage {
-                    // Show "Done" briefly, then auto-dismiss
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-                        speechRecognizer.shouldDismiss = true
+                    // Only auto-dismiss in word tracking mode.
+                    // In classic/silence-paused modes the speaker may still be
+                    // talking after the auto-scroll finishes, so keep the text
+                    // visible and let them dismiss manually (X button or Esc).
+                    if listeningMode == .wordTracking {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                            speechRecognizer.shouldDismiss = true
+                        }
                     }
                 } else if NotchSettings.shared.autoNextPage {
                     startCountdown()
@@ -1213,7 +1220,7 @@ struct FloatingOverlayView: View {
         VStack(spacing: 0) {
             if content.showPagePicker {
                 floatingPagePickerView
-            } else if isDone {
+            } else if isDone && (listeningMode == .wordTracking || hasNextPage) {
                 floatingDoneView
             } else {
                 floatingPrompterView
@@ -1260,11 +1267,14 @@ struct FloatingOverlayView: View {
         .animation(.easeInOut(duration: 0.5), value: isDone)
         .onChange(of: isDone) { _, done in
             if done {
-                // Stop listening when page is done
-                speechRecognizer.stop()
+                if listeningMode == .wordTracking {
+                    speechRecognizer.stop()
+                }
                 if !hasNextPage {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-                        speechRecognizer.shouldDismiss = true
+                    if listeningMode == .wordTracking {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                            speechRecognizer.shouldDismiss = true
+                        }
                     }
                 } else if followingCursor || NotchSettings.shared.autoNextPage {
                     startCountdown()

--- a/Textream/Textream/NotchOverlayController.swift
+++ b/Textream/Textream/NotchOverlayController.swift
@@ -534,6 +534,19 @@ struct StopButtonView: View {
     }
 }
 
+// MARK: - Notch Blur View (for transparency mode)
+
+struct NotchBlurView: NSViewRepresentable {
+    func makeNSView(context: Context) -> NSVisualEffectView {
+        let v = NSVisualEffectView()
+        v.blendingMode = .behindWindow
+        v.material = .hudWindow
+        v.state = .active
+        return v
+    }
+    func updateNSView(_ nsView: NSVisualEffectView, context: Context) {}
+}
+
 // MARK: - Dynamic Island Shape (concave top corners, convex bottom corners)
 
 struct DynamicIslandShape: Shape {
@@ -699,13 +712,34 @@ struct NotchOverlayView: View {
             let currentWidth = notchWidth + (geo.size.width - notchWidth) * expansion
 
             ZStack(alignment: .top) {
-                // Container shape
-                DynamicIslandShape(
-                    topInset: currentTopInset,
-                    bottomRadius: currentBottomRadius
-                )
-                .fill(.black)
-                .frame(width: currentWidth, height: currentHeight)
+                // Container shape — solid black or transparent with blur
+                let isTransparent = NotchSettings.shared.overlayTransparency
+                let transparencyOpacity = NotchSettings.shared.overlayTransparencyOpacity
+
+                if isTransparent {
+                    // Blurred background layer clipped to the Dynamic Island shape
+                    NotchBlurView()
+                        .clipShape(DynamicIslandShape(
+                            topInset: currentTopInset,
+                            bottomRadius: currentBottomRadius
+                        ))
+                        .frame(width: currentWidth, height: currentHeight)
+
+                    // Dark tint overlay so text remains readable
+                    DynamicIslandShape(
+                        topInset: currentTopInset,
+                        bottomRadius: currentBottomRadius
+                    )
+                    .fill(.black.opacity(1.0 - transparencyOpacity))
+                    .frame(width: currentWidth, height: currentHeight)
+                } else {
+                    DynamicIslandShape(
+                        topInset: currentTopInset,
+                        bottomRadius: currentBottomRadius
+                    )
+                    .fill(.black)
+                    .frame(width: currentWidth, height: currentHeight)
+                }
 
                 // Content - appears after container expands
                 if contentVisible {

--- a/Textream/Textream/NotchOverlayController.swift
+++ b/Textream/Textream/NotchOverlayController.swift
@@ -374,21 +374,27 @@ class NotchOverlayController: NSObject {
     }
 
     func dismiss() {
+        guard !isDismissing else { return }
+        isDismissing = true
+
         // Trigger the shrink animation
         speechRecognizer.shouldDismiss = true
         speechRecognizer.forceStop()
 
         // Wait for animation, then remove panel
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) { [weak self] in
-            self?.stopMouseTracking()
-            self?.stopCursorTracking()
-            self?.removeStopButton()
-            self?.removeEscMonitor()
-            self?.panel?.orderOut(nil)
-            self?.panel = nil
-            self?.frameTracker = nil
-            self?.speechRecognizer.shouldDismiss = false
-            self?.onComplete?()
+            guard let self else { return }
+            self.stopMouseTracking()
+            self.stopCursorTracking()
+            self.removeStopButton()
+            self.removeEscMonitor()
+            self.cancellables.removeAll()
+            self.panel?.orderOut(nil)
+            self.panel = nil
+            self.frameTracker = nil
+            self.speechRecognizer.shouldDismiss = false
+            self.isDismissing = false
+            self.onComplete?()
         }
     }
 
@@ -424,41 +430,40 @@ class NotchOverlayController: NSObject {
     }
 
     private func observeDismiss() {
-        // Poll for shouldAdvancePage (next page requested from overlay)
+        // Single timer polls all conditions instead of two separate timers
         Timer.publish(every: 0.1, on: .main, in: .common)
             .autoconnect()
             .sink { [weak self] _ in
                 guard let self else { return }
+
+                // Check for page advance
                 if self.speechRecognizer.shouldAdvancePage {
                     self.speechRecognizer.shouldAdvancePage = false
                     self.onNextPage?()
                 }
-                // Poll for page jump from page picker
+
+                // Check for page jump from page picker
                 if let targetIndex = self.overlayContent.jumpToPageIndex {
                     self.overlayContent.jumpToPageIndex = nil
                     TextreamService.shared.jumpToPage(index: targetIndex)
                 }
-            }
-            .store(in: &cancellables)
 
-        // Poll for shouldDismiss becoming true (from view setting it on completion)
-        Timer.publish(every: 0.1, on: .main, in: .common)
-            .autoconnect()
-            .sink { [weak self] _ in
-                guard let self, self.speechRecognizer.shouldDismiss, !self.isDismissing else { return }
-                self.isDismissing = true
-                // Wait for shrink animation, then cleanup
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
-                    self.stopMouseTracking()
-                    self.stopCursorTracking()
-                    self.removeStopButton()
-                    self.removeEscMonitor()
-                    self.cancellables.removeAll()
-                    self.panel?.orderOut(nil)
-                    self.panel = nil
-                    self.frameTracker = nil
-                    self.speechRecognizer.shouldDismiss = false
-                    self.onComplete?()
+                // Check for dismiss
+                if self.speechRecognizer.shouldDismiss, !self.isDismissing {
+                    self.isDismissing = true
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) { [weak self] in
+                        guard let self else { return }
+                        self.stopMouseTracking()
+                        self.stopCursorTracking()
+                        self.removeStopButton()
+                        self.removeEscMonitor()
+                        self.cancellables.removeAll()
+                        self.panel?.orderOut(nil)
+                        self.panel = nil
+                        self.frameTracker = nil
+                        self.speechRecognizer.shouldDismiss = false
+                        self.onComplete?()
+                    }
                 }
             }
             .store(in: &cancellables)

--- a/Textream/Textream/NotchOverlayController.swift
+++ b/Textream/Textream/NotchOverlayController.swift
@@ -45,6 +45,8 @@ class OverlayContent {
 }
 
 class NotchOverlayController: NSObject {
+    private let cursorOffset: CGFloat = 8
+    private let screenEdgeMargin: CGFloat = 5
     private var panel: NSPanel?
     let speechRecognizer = SpeechRecognizer()
     let overlayContent = OverlayContent()
@@ -174,21 +176,23 @@ class NotchOverlayController: NSObject {
     private func updateCursorPosition() {
         guard let panel else { return }
         let mouse = NSEvent.mouseLocation
-        let cursorOffset: CGFloat = 8
-        let x = mouse.x + cursorOffset
-        let h = panel.frame.height
-        var y = mouse.y - h
-        let w = panel.frame.width
+        guard let screen = screenUnderMouse() ?? panel.screen ?? NSScreen.main else { return }
+        let frame = cursorFollowingFrame(mouse: mouse, panelSize: panel.frame.size, screen: screen)
+        panel.setFrame(frame, display: false)
+    }
 
-        // Keep panel below the menu bar so the status bar stop button stays visible
-        if let screen = NSScreen.screens.first(where: { NSMouseInRect(mouse, $0.frame, false) }) {
-            let menuBarBottom = screen.visibleFrame.maxY
-            if y + h > menuBarBottom {
-                y = menuBarBottom - h
-            }
-        }
+    private func cursorFollowingFrame(mouse: NSPoint, panelSize: NSSize, screen: NSScreen) -> NSRect {
+        let screenFrame = screen.frame
 
-        panel.setFrame(NSRect(x: x, y: y, width: w, height: h), display: false)
+        let minimumX = screenFrame.minX + screenEdgeMargin
+        let maximumX = max(minimumX, screenFrame.maxX - panelSize.width - screenEdgeMargin)
+        let x = min(max(mouse.x + cursorOffset, minimumX), maximumX)
+
+        let minimumY = screenFrame.minY + screenEdgeMargin
+        let maximumY = max(minimumY, screen.visibleFrame.maxY - panelSize.height)
+        let y = min(max(mouse.y - panelSize.height, minimumY), maximumY)
+
+        return NSRect(origin: NSPoint(x: x, y: y), size: panelSize)
     }
 
     private func checkMouseScreen() {
@@ -272,9 +276,12 @@ class NotchOverlayController: NSObject {
         let panelHeight = settings.textAreaHeight
 
         let mouse = NSEvent.mouseLocation
-        let cursorOffset: CGFloat = 8
-        let xPosition = mouse.x + cursorOffset
-        let yPosition = mouse.y - panelHeight
+        let cursorScreen = screenUnderMouse() ?? screen
+        let initialFrame = cursorFollowingFrame(
+            mouse: mouse,
+            panelSize: NSSize(width: panelWidth, height: panelHeight),
+            screen: cursorScreen
+        )
 
         let floatingView = FloatingOverlayView(
             content: overlayContent,
@@ -285,7 +292,7 @@ class NotchOverlayController: NSObject {
         let contentView = NSHostingView(rootView: floatingView)
 
         let panel = NSPanel(
-            contentRect: NSRect(x: xPosition, y: yPosition, width: panelWidth, height: panelHeight),
+            contentRect: initialFrame,
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
             defer: false

--- a/Textream/Textream/NotchOverlayController.swift
+++ b/Textream/Textream/NotchOverlayController.swift
@@ -263,6 +263,8 @@ class NotchOverlayController: NSObject {
         if settings.notchDisplayMode == .followMouse {
             startMouseTracking()
         }
+
+        installKeyMonitor()
     }
 
     private func showFollowCursor(settings: NotchSettings, screen: NSScreen) {

--- a/Textream/Textream/NotchOverlayController.swift
+++ b/Textream/Textream/NotchOverlayController.swift
@@ -61,7 +61,7 @@ class NotchOverlayController: NSObject {
 
     func show(text: String, hasNextPage: Bool = false, onComplete: (() -> Void)? = nil) {
         self.onComplete = onComplete
-        self.onNextPage = { [weak self] in
+        self.onNextPage = {
             TextreamService.shared.advanceToNextPage()
         }
         self.isDismissing = false
@@ -906,7 +906,15 @@ struct NotchOverlayView: View {
                 .frame(width: 80, height: 24)
                 .clipped()
 
-                if listeningMode == .wordTracking {
+                if let error = speechRecognizer.error {
+                    Label(error, systemImage: "exclamationmark.triangle.fill")
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundStyle(.red.opacity(0.9))
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .help(error)
+                } else if listeningMode == .wordTracking {
                     Text(speechRecognizer.lastSpokenText.split(separator: " ").suffix(3).joined(separator: " "))
                         .font(.system(size: 11, weight: .medium))
                         .foregroundStyle(.white.opacity(0.5))
@@ -971,18 +979,26 @@ struct NotchOverlayView: View {
                     .buttonStyle(.plain)
                 } else {
                     Button {
-                        if speechRecognizer.isListening {
+                        if speechRecognizer.isListening || speechRecognizer.isStarting {
                             speechRecognizer.stop()
                         } else {
                             speechRecognizer.resume()
                         }
                     } label: {
-                        Image(systemName: speechRecognizer.isListening ? "mic.fill" : "mic.slash.fill")
-                            .font(.system(size: 10, weight: .bold))
-                            .foregroundStyle(speechRecognizer.isListening ? .yellow.opacity(0.8) : .white.opacity(0.6))
-                            .frame(width: 24, height: 24)
-                            .background(.white.opacity(0.15))
-                            .clipShape(Circle())
+                        Group {
+                            if speechRecognizer.isStarting {
+                                ProgressView()
+                                    .controlSize(.mini)
+                                    .tint(.white.opacity(0.8))
+                            } else {
+                                Image(systemName: speechRecognizer.isListening ? "mic.fill" : "mic.slash.fill")
+                                    .font(.system(size: 10, weight: .bold))
+                            }
+                        }
+                        .foregroundStyle(speechRecognizer.isListening ? .yellow.opacity(0.8) : .white.opacity(0.6))
+                        .frame(width: 24, height: 24)
+                        .background(.white.opacity(0.15))
+                        .clipShape(Circle())
                     }
                     .buttonStyle(.plain)
                 }
@@ -1384,7 +1400,15 @@ struct FloatingOverlayView: View {
                 )
                 .frame(width: 160, height: 24)
 
-                if listeningMode == .wordTracking {
+                if let error = speechRecognizer.error {
+                    Label(error, systemImage: "exclamationmark.triangle.fill")
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundStyle(.red.opacity(0.9))
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .help(error)
+                } else if listeningMode == .wordTracking {
                     Text(speechRecognizer.lastSpokenText.split(separator: " ").suffix(3).joined(separator: " "))
                         .font(.system(size: 11, weight: .medium))
                         .foregroundStyle(.white.opacity(0.5))
@@ -1450,18 +1474,26 @@ struct FloatingOverlayView: View {
                         .buttonStyle(.plain)
                     } else {
                         Button {
-                            if speechRecognizer.isListening {
+                            if speechRecognizer.isListening || speechRecognizer.isStarting {
                                 speechRecognizer.stop()
                             } else {
                                 speechRecognizer.resume()
                             }
                         } label: {
-                            Image(systemName: speechRecognizer.isListening ? "mic.fill" : "mic.slash.fill")
-                                .font(.system(size: 10, weight: .bold))
-                                .foregroundStyle(speechRecognizer.isListening ? .yellow.opacity(0.8) : .white.opacity(0.6))
-                                .frame(width: 24, height: 24)
-                                .background(.white.opacity(0.15))
-                                .clipShape(Circle())
+                            Group {
+                                if speechRecognizer.isStarting {
+                                    ProgressView()
+                                        .controlSize(.mini)
+                                        .tint(.white.opacity(0.8))
+                                } else {
+                                    Image(systemName: speechRecognizer.isListening ? "mic.fill" : "mic.slash.fill")
+                                        .font(.system(size: 10, weight: .bold))
+                                }
+                            }
+                            .foregroundStyle(speechRecognizer.isListening ? .yellow.opacity(0.8) : .white.opacity(0.6))
+                            .frame(width: 24, height: 24)
+                            .background(.white.opacity(0.15))
+                            .clipShape(Circle())
                         }
                         .buttonStyle(.plain)
                     }

--- a/Textream/Textream/NotchSettings.swift
+++ b/Textream/Textream/NotchSettings.swift
@@ -128,6 +128,43 @@ enum FontColorPreset: String, CaseIterable, Identifiable {
     }
 }
 
+// MARK: - Cue Brightness
+
+enum CueBrightness: String, CaseIterable, Identifiable {
+    case dim, low, medium, bright
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .dim:    return "Dim"
+        case .low:    return "Low"
+        case .medium: return "Medium"
+        case .bright: return "Bright"
+        }
+    }
+
+    /// Opacity for unread annotations
+    var unreadOpacity: Double {
+        switch self {
+        case .dim:    return 0.2
+        case .low:    return 0.35
+        case .medium: return 0.5
+        case .bright: return 0.8
+        }
+    }
+
+    /// Opacity for already-read annotations
+    var readOpacity: Double {
+        switch self {
+        case .dim:    return 0.5
+        case .low:    return 0.6
+        case .medium: return 0.7
+        case .bright: return 1.0
+        }
+    }
+}
+
 // MARK: - Overlay Mode
 
 enum OverlayMode: String, CaseIterable, Identifiable {
@@ -305,6 +342,14 @@ class NotchSettings {
         didSet { UserDefaults.standard.set(fontColorPreset.rawValue, forKey: "fontColorPreset") }
     }
 
+    var cueColorPreset: FontColorPreset {
+        didSet { UserDefaults.standard.set(cueColorPreset.rawValue, forKey: "cueColorPreset") }
+    }
+
+    var cueBrightness: CueBrightness {
+        didSet { UserDefaults.standard.set(cueBrightness.rawValue, forKey: "cueBrightness") }
+    }
+
     var overlayMode: OverlayMode {
         didSet { UserDefaults.standard.set(overlayMode.rawValue, forKey: "overlayMode") }
     }
@@ -418,6 +463,8 @@ class NotchSettings {
         self.fontSizePreset = FontSizePreset(rawValue: UserDefaults.standard.string(forKey: "fontSizePreset") ?? "") ?? .lg
         self.fontFamilyPreset = FontFamilyPreset(rawValue: UserDefaults.standard.string(forKey: "fontFamilyPreset") ?? "") ?? .sans
         self.fontColorPreset = FontColorPreset(rawValue: UserDefaults.standard.string(forKey: "fontColorPreset") ?? "") ?? .white
+        self.cueColorPreset = FontColorPreset(rawValue: UserDefaults.standard.string(forKey: "cueColorPreset") ?? "") ?? .white
+        self.cueBrightness = CueBrightness(rawValue: UserDefaults.standard.string(forKey: "cueBrightness") ?? "") ?? .dim
         self.overlayMode = OverlayMode(rawValue: UserDefaults.standard.string(forKey: "overlayMode") ?? "") ?? .pinned
         self.notchDisplayMode = NotchDisplayMode(rawValue: UserDefaults.standard.string(forKey: "notchDisplayMode") ?? "") ?? .followMouse
         let savedPinnedScreenID = UserDefaults.standard.integer(forKey: "pinnedScreenID")

--- a/Textream/Textream/NotchSettings.swift
+++ b/Textream/Textream/NotchSettings.swift
@@ -370,6 +370,14 @@ class NotchSettings {
         didSet { UserDefaults.standard.set(glassOpacity, forKey: "glassOpacity") }
     }
 
+    var overlayTransparency: Bool {
+        didSet { UserDefaults.standard.set(overlayTransparency, forKey: "overlayTransparency") }
+    }
+
+    var overlayTransparencyOpacity: Double {
+        didSet { UserDefaults.standard.set(overlayTransparencyOpacity, forKey: "overlayTransparencyOpacity") }
+    }
+
     var followCursorWhenUndocked: Bool {
         didSet { UserDefaults.standard.set(followCursorWhenUndocked, forKey: "followCursorWhenUndocked") }
     }
@@ -472,6 +480,9 @@ class NotchSettings {
         self.floatingGlassEffect = UserDefaults.standard.object(forKey: "floatingGlassEffect") as? Bool ?? false
         let savedOpacity = UserDefaults.standard.double(forKey: "glassOpacity")
         self.glassOpacity = savedOpacity > 0 ? savedOpacity : 0.15
+        self.overlayTransparency = UserDefaults.standard.object(forKey: "overlayTransparency") as? Bool ?? false
+        let savedTransparencyOpacity = UserDefaults.standard.double(forKey: "overlayTransparencyOpacity")
+        self.overlayTransparencyOpacity = savedTransparencyOpacity > 0 ? savedTransparencyOpacity : 0.85
         self.followCursorWhenUndocked = UserDefaults.standard.object(forKey: "followCursorWhenUndocked") as? Bool ?? false
         self.externalDisplayMode = ExternalDisplayMode(rawValue: UserDefaults.standard.string(forKey: "externalDisplayMode") ?? "") ?? .off
         let savedScreenID = UserDefaults.standard.integer(forKey: "externalScreenID")

--- a/Textream/Textream/NotchSettings.swift
+++ b/Textream/Textream/NotchSettings.swift
@@ -455,7 +455,8 @@ class NotchSettings {
 
     static let defaultWidth: CGFloat = 340
     static let defaultHeight: CGFloat = 150
-    static let defaultLocale: String = Locale.current.identifier
+    static let defaultLocale: String = SpeechLocaleSupport.closestSupportedLocale(to: Locale.current.identifier)?.identifier
+        ?? Locale.current.identifier
 
     static let minWidth: CGFloat = 310
     static let maxWidth: CGFloat = 500
@@ -467,7 +468,9 @@ class NotchSettings {
         let savedHeight = UserDefaults.standard.double(forKey: "textAreaHeight")
         self.notchWidth = savedWidth > 0 ? CGFloat(savedWidth) : Self.defaultWidth
         self.textAreaHeight = savedHeight > 0 ? CGFloat(savedHeight) : Self.defaultHeight
-        self.speechLocale = UserDefaults.standard.string(forKey: "speechLocale") ?? Self.defaultLocale
+        let preferredSpeechLocale = UserDefaults.standard.string(forKey: "speechLocale") ?? Self.defaultLocale
+        self.speechLocale = SpeechLocaleSupport.closestSupportedLocale(to: preferredSpeechLocale)?.identifier
+            ?? Self.defaultLocale
         self.fontSizePreset = FontSizePreset(rawValue: UserDefaults.standard.string(forKey: "fontSizePreset") ?? "") ?? .lg
         self.fontFamilyPreset = FontFamilyPreset(rawValue: UserDefaults.standard.string(forKey: "fontFamilyPreset") ?? "") ?? .sans
         self.fontColorPreset = FontColorPreset(rawValue: UserDefaults.standard.string(forKey: "fontColorPreset") ?? "") ?? .white

--- a/Textream/Textream/SettingsView.swift
+++ b/Textream/Textream/SettingsView.swift
@@ -139,7 +139,7 @@ struct NotchPreviewContent: View {
     @Bindable var settings: NotchSettings
     let menuBarHeight: CGFloat
 
-    private static let loremWords = "Lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua Ut enim ad minim veniam quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur Excepteur sint occaecat cupidatat non proident sunt in culpa qui officia deserunt mollit anim id est laborum Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium totam rem aperiam eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt".split(separator: " ").map(String.init)
+    private static let loremWords = "Lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor [pause] incididunt ut labore et dolore magna aliqua Ut enim ad minim veniam quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur Excepteur sint occaecat cupidatat non proident sunt in culpa qui officia deserunt mollit anim id est laborum Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium totam rem aperiam eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt".split(separator: " ").map(String.init)
 
     private let highlightedCount = 42
     @State private var previewWordProgress: Double = 0
@@ -198,6 +198,9 @@ struct NotchPreviewContent: View {
                         highlightedCharCount: settings.listeningMode == .wordTracking ? highlightedCount : Self.loremWords.count * 5,
                         font: settings.font,
                         highlightColor: settings.fontColorPreset.color,
+                        cueColor: settings.cueColorPreset.color,
+                        cueUnreadOpacity: settings.cueBrightness.unreadOpacity,
+                        cueReadOpacity: settings.cueBrightness.readOpacity,
                         smoothScroll: settings.listeningMode != .wordTracking,
                         smoothWordProgress: previewWordProgress,
                         isListening: settings.listeningMode != .wordTracking
@@ -559,6 +562,63 @@ struct SettingsView: View {
                         .buttonStyle(.plain)
                     }
                 }
+
+                // Cue Color
+                Text("Cue Color")
+                    .font(.system(size: 13, weight: .medium))
+
+                HStack(spacing: 8) {
+                    ForEach(FontColorPreset.allCases) { preset in
+                        Button {
+                            withAnimation(.easeInOut(duration: 0.2)) {
+                                settings.cueColorPreset = preset
+                            }
+                        } label: {
+                            VStack(spacing: 6) {
+                                Circle()
+                                    .fill(preset.color)
+                                    .frame(width: 22, height: 22)
+                                    .overlay(
+                                        Circle()
+                                            .strokeBorder(Color.primary.opacity(0.15), lineWidth: 1)
+                                    )
+                                    .overlay(
+                                        settings.cueColorPreset == preset
+                                            ? Image(systemName: "checkmark")
+                                                .font(.system(size: 10, weight: .bold))
+                                                .foregroundStyle(preset == .white ? .black : .white)
+                                            : nil
+                                    )
+                                Text(preset.label)
+                                    .font(.system(size: 10, weight: .medium))
+                                    .foregroundStyle(settings.cueColorPreset == preset ? .primary : .secondary)
+                            }
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 8)
+                            .background(
+                                RoundedRectangle(cornerRadius: 10)
+                                    .fill(settings.cueColorPreset == preset ? preset.color.opacity(0.1) : Color.primary.opacity(0.05))
+                            )
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 10)
+                                    .strokeBorder(settings.cueColorPreset == preset ? preset.color.opacity(0.4) : Color.clear, lineWidth: 1.5)
+                            )
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+
+                // Cue Brightness
+                Text("Cue Brightness")
+                    .font(.system(size: 13, weight: .medium))
+
+                Picker("", selection: $settings.cueBrightness) {
+                    ForEach(CueBrightness.allCases) { brightness in
+                        Text(brightness.label).tag(brightness)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
 
                 Divider()
 
@@ -1261,6 +1321,8 @@ struct SettingsView: View {
         settings.fontSizePreset = .lg
         settings.fontFamilyPreset = .sans
         settings.fontColorPreset = .white
+        settings.cueColorPreset = .white
+        settings.cueBrightness = .dim
         settings.overlayMode = .pinned
         settings.notchDisplayMode = .followMouse
         settings.pinnedScreenID = 0

--- a/Textream/Textream/SettingsView.swift
+++ b/Textream/Textream/SettingsView.swift
@@ -159,11 +159,29 @@ struct NotchPreviewContent: View {
 
             ZStack(alignment: .top) {
                 // Shape: concave corners flatten via cornerPhase, then cross-fade to rounded via offsetPhase
-                DynamicIslandShape(
-                    topInset: 16 * (1 - cornerPhase),
-                    bottomRadius: 18
-                )
-                .fill(.black)
+                let isTransparent = settings.overlayTransparency && settings.overlayMode == .pinned
+                Group {
+                    if isTransparent {
+                        ZStack {
+                            NotchBlurView()
+                            DynamicIslandShape(
+                                topInset: 16 * (1 - cornerPhase),
+                                bottomRadius: 18
+                            )
+                            .fill(.black.opacity(1.0 - settings.overlayTransparencyOpacity))
+                        }
+                        .clipShape(DynamicIslandShape(
+                            topInset: 16 * (1 - cornerPhase),
+                            bottomRadius: 18
+                        ))
+                    } else {
+                        DynamicIslandShape(
+                            topInset: 16 * (1 - cornerPhase),
+                            bottomRadius: 18
+                        )
+                        .fill(.black)
+                    }
+                }
                 .opacity(Double(1 - offsetPhase))
                 .frame(width: currentWidth, height: contentHeight)
 
@@ -796,6 +814,48 @@ struct SettingsView: View {
                             onRefresh: { refreshOverlayScreens() }
                         )
                     }
+
+                    Divider()
+
+                    Toggle(isOn: $settings.overlayTransparency) {
+                        Text("Transparency")
+                            .font(.system(size: 13, weight: .medium))
+                    }
+                    .toggleStyle(.switch)
+                    .controlSize(.small)
+
+                    Text("Makes the overlay see-through so desktop content shows through.")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+
+                    if settings.overlayTransparency {
+                        VStack(alignment: .leading, spacing: 6) {
+                            HStack {
+                                Text("Amount")
+                                    .font(.system(size: 12))
+                                    .foregroundStyle(.secondary)
+                                Spacer()
+                                Text("\(Int(settings.overlayTransparencyOpacity * 100))%")
+                                    .font(.system(size: 11, weight: .regular, design: .monospaced))
+                                    .foregroundStyle(.tertiary)
+                            }
+                            Slider(
+                                value: $settings.overlayTransparencyOpacity,
+                                in: 0.2...0.95,
+                                step: 0.05
+                            )
+                            HStack {
+                                Text("More transparent")
+                                    .font(.system(size: 10))
+                                    .foregroundStyle(.tertiary)
+                                Spacer()
+                                Text("Less transparent")
+                                    .font(.system(size: 10))
+                                    .foregroundStyle(.tertiary)
+                            }
+                        }
+                        .transition(.opacity.combined(with: .move(edge: .top)))
+                    }
                 }
 
                 if settings.overlayMode == .floating {
@@ -1328,6 +1388,8 @@ struct SettingsView: View {
         settings.pinnedScreenID = 0
         settings.floatingGlassEffect = false
         settings.glassOpacity = 0.15
+        settings.overlayTransparency = false
+        settings.overlayTransparencyOpacity = 0.85
         settings.followCursorWhenUndocked = false
         settings.fullscreenScreenID = 0
         settings.externalDisplayMode = .off

--- a/Textream/Textream/SettingsView.swift
+++ b/Textream/Textream/SettingsView.swift
@@ -105,12 +105,33 @@ class NotchPreviewController {
     private func cursorFrame(for panel: NSPanel, settings: NotchSettings) -> NSRect {
         let mouse = NSEvent.mouseLocation
         let cursorOffset: CGFloat = 8
+        let screenEdgeMargin: CGFloat = 5
+        let floatingTopPadding: CGFloat = 14
+        let floatingVerticalOffset: CGFloat = 60
         let maxWidth = panel.frame.width
         let notchWidth = settings.notchWidth
         let panelHeight = panel.frame.height
+        let visibleHeight = floatingTopPadding + settings.textAreaHeight
+        let horizontalInset = (maxWidth - notchWidth) / 2
 
-        let panelX = mouse.x + cursorOffset - (maxWidth - notchWidth) / 2
-        let panelY = mouse.y + 60 - panelHeight
+        var visibleLeft = mouse.x + cursorOffset
+        var visibleBottom = mouse.y - visibleHeight
+
+        if let screen = NSScreen.screens.first(where: { NSMouseInRect(mouse, $0.frame, false) })
+            ?? panel.screen
+            ?? NSScreen.main {
+            let screenFrame = screen.frame
+            let minimumVisibleLeft = screenFrame.minX + screenEdgeMargin
+            let maximumVisibleLeft = max(
+                minimumVisibleLeft,
+                screenFrame.maxX - notchWidth - screenEdgeMargin
+            )
+            visibleLeft = min(max(visibleLeft, minimumVisibleLeft), maximumVisibleLeft)
+            visibleBottom = max(visibleBottom, screenFrame.minY + screenEdgeMargin)
+        }
+
+        let panelX = visibleLeft - horizontalInset
+        let panelY = visibleBottom - (panelHeight - floatingVerticalOffset - visibleHeight)
         return NSRect(x: panelX, y: panelY, width: maxWidth, height: panelHeight)
     }
 

--- a/Textream/Textream/SpeechRecognizer.swift
+++ b/Textream/Textream/SpeechRecognizer.swift
@@ -287,10 +287,10 @@ class SpeechRecognizer {
         recognitionRequest.shouldReportPartialResults = true
 
         let inputNode = audioEngine.inputNode
-        let recordingFormat = inputNode.outputFormat(forBus: 0)
+        let hardwareFormat = inputNode.outputFormat(forBus: 0)
 
         // Guard against invalid format during device transitions (e.g. mic switch)
-        guard recordingFormat.sampleRate > 0, recordingFormat.channelCount > 0 else {
+        guard hardwareFormat.sampleRate > 0, hardwareFormat.channelCount > 0 else {
             // Retry after a longer delay to let the audio system settle
             if retryCount < maxRetries {
                 retryCount += 1
@@ -301,6 +301,17 @@ class SpeechRecognizer {
             }
             return
         }
+
+        // SFSpeechRecognizer requires mono audio. Multi-channel devices (e.g.
+        // RODECaster Pro II at 2ch/48kHz) cause the recognition task to silently
+        // return no results. Request a mono tap and let AVAudioEngine downmix.
+        let monoFormat = AVAudioFormat(
+            commonFormat: hardwareFormat.commonFormat,
+            sampleRate: hardwareFormat.sampleRate,
+            channels: 1,
+            interleaved: hardwareFormat.isInterleaved
+        )
+        let tapFormat = (hardwareFormat.channelCount > 1) ? monoFormat : hardwareFormat
 
         // Observe audio configuration changes (e.g. mic switched externally) to restart gracefully
         configurationChangeObserver = NotificationCenter.default.addObserver(
@@ -315,7 +326,7 @@ class SpeechRecognizer {
         // Belt-and-suspenders: ensure no stale tap exists before installing
         inputNode.removeTap(onBus: 0)
 
-        inputNode.installTap(onBus: 0, bufferSize: 1024, format: nil) { [weak self] buffer, _ in
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: tapFormat) { [weak self] buffer, _ in
             recognitionRequest.append(buffer)
 
             guard let channelData = buffer.floatChannelData?[0] else { return }

--- a/Textream/Textream/SpeechRecognizer.swift
+++ b/Textream/Textream/SpeechRecognizer.swift
@@ -106,12 +106,18 @@ class SpeechRecognizer {
     /// Sliding window of recent match positions for confidence gating.
     /// We require 2-of-3 recent results to agree before committing a forward jump.
     private var recentMatchPositions: [Int] = []
-    /// Chars of the running transcript to ignore when matching — set on jumps
-    /// so the task can keep running instead of being restarted (a restart
-    /// drops the audio spoken during the restart window and takes ~1s to
-    /// warm, which loses exactly the words the user re-speaks after a jump).
-    /// Reset to 0 whenever a new recognition task starts a fresh transcript.
-    private var spokenAnchor: Int = 0
+    /// Transcript prefix to ignore when matching — set on jumps so the task
+    /// can keep running instead of being restarted (a restart loses the words
+    /// the user re-speaks right after the jump). Stored as the prefix string,
+    /// not a char count: partial results revise earlier text, and trimming by
+    /// the surviving common prefix avoids swallowing post-jump speech when
+    /// the pre-jump portion changes length. Cleared whenever a new
+    /// recognition task starts a fresh transcript.
+    private var spokenAnchorPrefix: String = ""
+    /// Results computed before a jump can be delivered after it; matching
+    /// ignores results for a short window so pre-jump speech isn't matched
+    /// against the text at the new offset.
+    private var lastJumpAt: Date = .distantPast
 
     /// Update the source text while preserving the current recognized char count.
     /// Used by Director Mode to live-edit unread text without resetting read progress.
@@ -126,14 +132,27 @@ class SpeechRecognizer {
     }
 
     /// Jump highlight to a specific char offset (e.g. when user taps a word).
-    /// Keeps the recognition task alive and anchors matching past the
-    /// already-spoken transcript.
+    /// Nearby jumps keep the recognition task alive and anchor matching past
+    /// the already-spoken transcript, so tracking resumes on the first
+    /// re-spoken word. Far jumps restart the task instead: contextualStrings
+    /// are built for the section being read, and after a page-scale jump
+    /// stale hints hurt recognition more than the task warm-up costs.
+    /// retryCount is deliberately not touched here — resetting it on every
+    /// tap would let a user keep a failing availability-retry loop alive
+    /// forever.
     func jumpTo(charOffset: Int) {
+        let distance = abs(charOffset - recognizedCharCount)
         recognizedCharCount = charOffset
         matchStartOffset = charOffset
-        retryCount = 0
         recentMatchPositions = []
-        spokenAnchor = lastSpokenText.count
+        if isListening && (distance > 500 || !audioEngine.isRunning) {
+            // Far jump, or the engine died without a config-change callback —
+            // fall back to a full restart (also refreshes contextualStrings).
+            restartRecognition()
+            return
+        }
+        spokenAnchorPrefix = lastSpokenText
+        lastJumpAt = Date()
     }
 
     func start(with text: String) {
@@ -272,7 +291,10 @@ class SpeechRecognizer {
     private func beginRecognition() {
         // Ensure clean state
         cleanupRecognition()
-        spokenAnchor = 0 // new session = fresh transcript
+        // New session = fresh transcript (see restartTask for why
+        // lastSpokenText must be cleared alongside the anchor)
+        spokenAnchorPrefix = ""
+        lastSpokenText = ""
 
         // Create a fresh engine so it picks up the current hardware format.
         // AVAudioEngine caches the device format internally and reset() alone
@@ -306,11 +328,18 @@ class SpeechRecognizer {
         }
 
         speechRecognizer = SFSpeechRecognizer(locale: Locale(identifier: NotchSettings.shared.speechLocale))
-        guard let speechRecognizer, speechRecognizer.isAvailable else {
-            // Availability is often transient (the recognition service churns
-            // briefly after a task cancellation or device change). Giving up
-            // here leaves the engine stopped and the app deaf — retry like
-            // the invalid-format guard below does.
+        guard let speechRecognizer else {
+            // nil means the locale isn't supported for speech recognition —
+            // that's permanent, so fail immediately instead of retrying.
+            error = "Speech recognition isn't supported for the selected language"
+            isListening = false
+            return
+        }
+        guard speechRecognizer.isAvailable else {
+            // Unavailability is often transient (the recognition service
+            // churns briefly after a task cancellation or device change).
+            // Giving up here leaves the engine stopped and the app deaf —
+            // retry like the invalid-format guard below does.
             if retryCount < maxRetries {
                 retryCount += 1
                 scheduleBeginRecognition(after: 0.5)
@@ -487,7 +516,12 @@ class SpeechRecognizer {
         // Update match offset before restarting
         matchStartOffset = recognizedCharCount
         recentMatchPositions = []
-        spokenAnchor = 0 // new task = fresh transcript
+        // New task = fresh transcript. lastSpokenText must be cleared too:
+        // a jump taken before the first new result would otherwise anchor on
+        // the old task's transcript and trim away everything the new task
+        // ever produces.
+        spokenAnchorPrefix = ""
+        lastSpokenText = ""
 
         // Cancel any pending restart to avoid stale beginRecognition clobbering this session
         pendingRestart?.cancel()
@@ -533,6 +567,8 @@ class SpeechRecognizer {
             } else {
                 error = "Speech recognizer not available"
                 isListening = false
+                // Don't leave the mic hot with no session consuming it
+                cleanupAudioEngine()
             }
             return
         }
@@ -601,10 +637,21 @@ class SpeechRecognizer {
     // MARK: - Fuzzy character-level matching
 
     private func matchCharacters(spoken fullSpoken: String) {
-        // Ignore transcript from before the most recent jump
-        let spoken = spokenAnchor > 0
-            ? String(fullSpoken.dropFirst(min(spokenAnchor, fullSpoken.count)))
-            : fullSpoken
+        // Results computed before a jump can be delivered just after it —
+        // don't match pre-jump speech against the text at the new offset.
+        guard Date().timeIntervalSince(lastJumpAt) > 0.3 else { return }
+
+        // Ignore transcript from before the most recent jump. Trim by the
+        // common prefix that survived the recognizer's revisions, but never
+        // less than the anchor length minus a small slack — a revision very
+        // early in the transcript would otherwise leak the whole pre-jump
+        // transcript back into matching.
+        var spoken = fullSpoken
+        if !spokenAnchorPrefix.isEmpty {
+            let common = zip(spokenAnchorPrefix, fullSpoken).prefix(while: { $0 == $1 }).count
+            let trimLen = min(fullSpoken.count, max(common, spokenAnchorPrefix.count - 24))
+            spoken = String(fullSpoken.dropFirst(trimLen))
+        }
         guard !spoken.isEmpty else { return }
 
         // Strategy 1: character-level fuzzy match from the start offset

--- a/Textream/Textream/SpeechRecognizer.swift
+++ b/Textream/Textream/SpeechRecognizer.swift
@@ -101,6 +101,11 @@ class SpeechRecognizer {
     private var pendingRestart: DispatchWorkItem?
     private var sessionGeneration: Int = 0
     private var suppressConfigChange: Bool = false
+    private var requestLock = NSLock()
+    private var preemptiveRestartTimer: Timer?
+    /// Sliding window of recent match positions for confidence gating.
+    /// We require 2-of-3 recent results to agree before committing a forward jump.
+    private var recentMatchPositions: [Int] = []
 
     /// Update the source text while preserving the current recognized char count.
     /// Used by Director Mode to live-edit unread text without resetting read progress.
@@ -111,6 +116,7 @@ class SpeechRecognizer {
         normalizedSource = Self.normalize(collapsed)
         recognizedCharCount = min(preservingCharCount, collapsed.count)
         matchStartOffset = recognizedCharCount
+        recentMatchPositions = []
     }
 
     /// Jump highlight to a specific char offset (e.g. when user taps a word)
@@ -118,6 +124,7 @@ class SpeechRecognizer {
         recognizedCharCount = charOffset
         matchStartOffset = charOffset
         retryCount = 0
+        recentMatchPositions = []
         if isListening {
             restartRecognition()
         }
@@ -135,6 +142,7 @@ class SpeechRecognizer {
         recognizedCharCount = 0
         matchStartOffset = 0
         retryCount = 0
+        recentMatchPositions = []
         error = nil
         sessionGeneration += 1
 
@@ -199,33 +207,47 @@ class SpeechRecognizer {
         isListening = false
         sourceText = ""
         retryCount = maxRetries
+        recentMatchPositions = []
         cleanupRecognition()
     }
 
     func resume() {
         retryCount = 0
         matchStartOffset = recognizedCharCount
+        recentMatchPositions = []
         shouldDismiss = false
         beginRecognition()
     }
 
-    private func cleanupRecognition() {
+    private func cleanupRecognitionTask() {
         // Cancel any pending restart to prevent overlapping beginRecognition calls
         pendingRestart?.cancel()
         pendingRestart = nil
+
+        stopPreemptiveTimer()
 
         if let observer = configurationChangeObserver {
             NotificationCenter.default.removeObserver(observer)
             configurationChangeObserver = nil
         }
+        requestLock.lock()
         recognitionRequest?.endAudio()
         recognitionRequest = nil
+        requestLock.unlock()
         recognitionTask?.cancel()
         recognitionTask = nil
+    }
+
+    private func cleanupAudioEngine() {
         if audioEngine.isRunning {
             audioEngine.stop()
         }
         audioEngine.inputNode.removeTap(onBus: 0)
+    }
+
+    private func cleanupRecognition() {
+        cleanupRecognitionTask()
+        cleanupAudioEngine()
     }
 
     /// Coalesces all delayed beginRecognition() calls into a single pending work item.
@@ -286,6 +308,16 @@ class SpeechRecognizer {
         guard let recognitionRequest else { return }
         recognitionRequest.shouldReportPartialResults = true
 
+        // Add contextual strings from the source text to improve STT accuracy
+        let upcoming = String(sourceText.dropFirst(matchStartOffset))
+        let contextWords = upcoming.split(separator: " ")
+            .map { String($0).lowercased().filter { $0.isLetter || $0.isNumber } }
+            .filter { $0.count >= 5 }
+        let uniqueContextWords = Array(Set(contextWords).prefix(50))
+        if !uniqueContextWords.isEmpty {
+            recognitionRequest.contextualStrings = uniqueContextWords
+        }
+
         let inputNode = audioEngine.inputNode
         let hardwareFormat = inputNode.outputFormat(forBus: 0)
 
@@ -327,7 +359,7 @@ class SpeechRecognizer {
         inputNode.removeTap(onBus: 0)
 
         inputNode.installTap(onBus: 0, bufferSize: 1024, format: tapFormat) { [weak self] buffer, _ in
-            recognitionRequest.append(buffer)
+            self?.appendBufferToRequest(buffer)
 
             guard let channelData = buffer.floatChannelData?[0] else { return }
             let frameLength = Int(buffer.frameLength)
@@ -359,11 +391,33 @@ class SpeechRecognizer {
                     self.matchCharacters(spoken: spoken)
                 }
             }
-            if error != nil {
+            if let error {
                 DispatchQueue.main.async {
                     // If recognitionRequest is nil, cleanup already ran (intentional cancel) — don't retry
                     guard self.recognitionRequest != nil else { return }
-                    if self.isListening && !self.shouldDismiss && !self.sourceText.isEmpty && self.retryCount < self.maxRetries {
+                    guard self.isListening && !self.shouldDismiss && !self.sourceText.isEmpty else {
+                        self.isListening = false
+                        return
+                    }
+
+                    self.matchStartOffset = self.recognizedCharCount
+
+                    // Distinguish timeout errors (expected every ~60s) from real errors.
+                    // SFSpeechRecognizer timeout is error code 1110 in kAFAssistantErrorDomain,
+                    // or 216 (kAudioConverterErr_FormatNotSupported). Retry immediately for
+                    // timeouts with no retry limit; use backoff for real errors.
+                    let nsError = error as NSError
+                    let isTimeout = nsError.code == 1110 || nsError.code == 216
+
+                    if isTimeout {
+                        // Expected timeout — restart immediately, no retry limit
+                        self.retryCount = 0
+                        if self.audioEngine.isRunning {
+                            self.restartTask()
+                        } else {
+                            self.scheduleBeginRecognition(after: 0.1)
+                        }
+                    } else if self.retryCount < self.maxRetries {
                         self.retryCount += 1
                         let delay = min(Double(self.retryCount) * 0.5, 1.5)
                         self.scheduleBeginRecognition(after: delay)
@@ -378,6 +432,7 @@ class SpeechRecognizer {
             audioEngine.prepare()
             try audioEngine.start()
             isListening = true
+            startPreemptiveTimer()
         } catch {
             // Transient failure after a device switch — retry with longer delay
             if retryCount < maxRetries {
@@ -391,12 +446,131 @@ class SpeechRecognizer {
     }
 
     private func restartRecognition() {
-        // Reset retries so the fresh engine gets a full set of attempts
         retryCount = 0
         isListening = true
-        // Longer delay to let the audio system fully settle after a device change
-        cleanupRecognition()
-        scheduleBeginRecognition(after: 0.5)
+        if audioEngine.isRunning {
+            restartTask()
+        } else {
+            cleanupRecognition()
+            scheduleBeginRecognition(after: 0.5)
+        }
+    }
+
+    // MARK: - Thread-safe buffer appending
+
+    private func appendBufferToRequest(_ buffer: AVAudioPCMBuffer) {
+        requestLock.lock()
+        recognitionRequest?.append(buffer)
+        requestLock.unlock()
+    }
+
+    // MARK: - Soft restart (task only, keeps audio engine running)
+
+    private func restartTask() {
+        // Update match offset before restarting
+        matchStartOffset = recognizedCharCount
+        recentMatchPositions = []
+
+        // Cancel any pending restart to avoid stale beginRecognition clobbering this session
+        pendingRestart?.cancel()
+        pendingRestart = nil
+
+        // Cancel the old task and atomically swap to a new request under lock.
+        // The lock prevents the audio tap from appending to the old request
+        // between endAudio() and the new assignment.
+        let newRequest = SFSpeechAudioBufferRecognitionRequest()
+        newRequest.shouldReportPartialResults = true
+
+        // Add contextual strings for the remaining text
+        let upcoming = String(sourceText.dropFirst(matchStartOffset))
+        let contextWords = upcoming.split(separator: " ")
+            .map { String($0).lowercased().filter { $0.isLetter || $0.isNumber } }
+            .filter { $0.count >= 5 }
+        let uniqueWords = Array(Set(contextWords).prefix(50))
+        if !uniqueWords.isEmpty {
+            newRequest.contextualStrings = uniqueWords
+        }
+
+        // Nil out recognitionRequest before cancelling the old task so the
+        // old task's error callback sees nil and skips retry logic. Then set
+        // the new request after cancellation.
+        requestLock.lock()
+        recognitionRequest?.endAudio()
+        recognitionRequest = nil
+        requestLock.unlock()
+        recognitionTask?.cancel()
+        recognitionTask = nil
+
+        requestLock.lock()
+        recognitionRequest = newRequest
+        requestLock.unlock()
+
+        // Start new recognition task
+        guard let speechRecognizer, speechRecognizer.isAvailable else {
+            error = "Speech recognizer not available"
+            isListening = false
+            return
+        }
+
+        let currentGeneration = sessionGeneration
+        recognitionTask = speechRecognizer.recognitionTask(with: newRequest) { [weak self] result, error in
+            guard let self else { return }
+            if let result {
+                let spoken = result.bestTranscription.formattedString
+                DispatchQueue.main.async {
+                    guard self.sessionGeneration == currentGeneration else { return }
+                    self.retryCount = 0
+                    self.lastSpokenText = spoken
+                    self.matchCharacters(spoken: spoken)
+                }
+            }
+            if let error {
+                DispatchQueue.main.async {
+                    guard self.recognitionRequest != nil else { return }
+                    guard self.isListening && !self.shouldDismiss && !self.sourceText.isEmpty else {
+                        self.isListening = false
+                        return
+                    }
+
+                    self.matchStartOffset = self.recognizedCharCount
+
+                    let nsError = error as NSError
+                    let isTimeout = nsError.code == 1110 || nsError.code == 216
+
+                    if isTimeout {
+                        self.retryCount = 0
+                        if self.audioEngine.isRunning {
+                            self.restartTask()
+                        } else {
+                            self.scheduleBeginRecognition(after: 0.1)
+                        }
+                    } else if self.retryCount < self.maxRetries {
+                        self.retryCount += 1
+                        let delay = min(Double(self.retryCount) * 0.5, 1.5)
+                        self.scheduleBeginRecognition(after: delay)
+                    } else {
+                        self.isListening = false
+                    }
+                }
+            }
+        }
+
+        startPreemptiveTimer()
+    }
+
+    // MARK: - Pre-emptive restart timer
+
+    private func startPreemptiveTimer() {
+        preemptiveRestartTimer?.invalidate()
+        preemptiveRestartTimer = Timer.scheduledTimer(withTimeInterval: 55.0, repeats: true) { [weak self] _ in
+            guard let self, self.isListening, !self.sourceText.isEmpty else { return }
+            self.restartTask()
+        }
+    }
+
+    private func stopPreemptiveTimer() {
+        preemptiveRestartTimer?.invalidate()
+        preemptiveRestartTimer = nil
     }
 
     // MARK: - Fuzzy character-level matching
@@ -408,19 +582,57 @@ class SpeechRecognizer {
         // Strategy 2: word-level match (handles STT word substitutions)
         let wordResult = wordLevelMatch(spoken: spoken)
 
-        let best = max(charResult, wordResult)
+        // Use agreement-based selection instead of blind max().
+        // If both strategies agree within a tolerance, use the average.
+        // If they disagree wildly, use the more conservative (lower) result
+        // to avoid false-positive jumps.
+        let best: Int
+        let tolerance = 20 // characters
+        if abs(charResult - wordResult) <= tolerance {
+            best = (charResult + wordResult) / 2
+        } else {
+            best = min(charResult, wordResult)
+        }
 
-        // Only move forward from the match start offset
         let newCount = matchStartOffset + best
-        if newCount > recognizedCharCount {
-            recognizedCharCount = min(newCount, sourceText.count)
+        guard newCount > recognizedCharCount else { return }
+
+        let candidate = min(newCount, sourceText.count)
+
+        // Confidence gating: require 2-of-3 recent results to agree on
+        // forward movement to avoid single-result false-positive jumps.
+        recentMatchPositions.append(candidate)
+        if recentMatchPositions.count > 3 {
+            recentMatchPositions.removeFirst()
+        }
+
+        // Check if at least 2 of the recent positions agree (within tolerance)
+        let agreementThreshold = 10 // characters
+        var confirmed = false
+        if recentMatchPositions.count >= 2 {
+            var agreeCount = 0
+            for pos in recentMatchPositions {
+                if abs(pos - candidate) <= agreementThreshold {
+                    agreeCount += 1
+                }
+            }
+            confirmed = agreeCount >= 2
+        }
+
+        // Small forward movements (< 1 word length) are always allowed
+        // to keep the highlight responsive for normal reading
+        let smallStep = candidate - recognizedCharCount <= 15
+
+        if confirmed || smallStep {
+            recognizedCharCount = candidate
         }
     }
 
     private func charLevelMatch(spoken: String) -> Int {
         let remainingSource = String(sourceText.dropFirst(matchStartOffset))
-        let src = Array(remainingSource.lowercased().unicodeScalars).map { Character($0) }
-        let spk = Array(Self.normalize(spoken).unicodeScalars).map { Character($0) }
+        // Use Character arrays (not unicodeScalars) so counts match sourceText.count
+        let src = Array(remainingSource.lowercased())
+        let spk = Array(Self.normalize(spoken))
 
         var si = 0
         var ri = 0
@@ -477,10 +689,10 @@ class SpeechRecognizer {
                 }
                 if found { continue }
 
-                // Skip both (substitution)
-                si += 1
+                // No resync found — advance spoken pointer only.
+                // Do NOT advance lastGoodOrigIndex; this is a genuine mismatch,
+                // not a confirmed match position.
                 ri += 1
-                lastGoodOrigIndex = si
             }
         }
 
@@ -517,13 +729,14 @@ class SpeechRecognizer {
                 .filter { $0.isLetter || $0.isNumber }
 
             if srcWord == spkWord || isFuzzyMatch(srcWord, spkWord) {
-                // Count original chars including trailing punctuation, plus space
+                // Count original chars including trailing punctuation
                 matchedCharCount += sourceWords[si].count
-                if si < sourceWords.count - 1 {
-                    matchedCharCount += 1 // space
-                }
                 si += 1
                 ri += 1
+                // Add space separator only if there's a following word
+                if si < sourceWords.count {
+                    matchedCharCount += 1
+                }
             } else {
                 // Try skipping up to 3 spoken words (STT hallucinated words)
                 var foundSpk = false
@@ -581,16 +794,16 @@ class SpeechRecognizer {
         if a.isEmpty || b.isEmpty { return false }
         // Exact match
         if a == b { return true }
-        // One starts with the other (phonetic prefix: "not" ~ "notch")
-        if a.hasPrefix(b) || b.hasPrefix(a) { return true }
-        // One contains the other
-        if a.contains(b) || b.contains(a) { return true }
-        // Shared prefix >= 60% of shorter word
-        let shared = zip(a, b).prefix(while: { $0 == $1 }).count
         let shorter = min(a.count, b.count)
-        if shorter >= 2 && shared >= max(2, shorter * 3 / 5) { return true }
-        // Edit distance tolerance
+        // Prefix match — only for words with at least 3 chars to avoid
+        // false positives like "or" matching "organization"
+        if shorter >= 3 && (a.hasPrefix(b) || b.hasPrefix(a)) { return true }
+        // Shared prefix >= 60% of shorter word (min 3 chars shared)
+        let shared = zip(a, b).prefix(while: { $0 == $1 }).count
+        if shorter >= 3 && shared >= max(3, shorter * 3 / 5) { return true }
+        // Edit distance tolerance — stricter for very short words
         let dist = editDistance(a, b)
+        if shorter <= 2 { return false } // 2-char words must be exact
         if shorter <= 4 { return dist <= 1 }
         if shorter <= 8 { return dist <= 2 }
         return dist <= max(a.count, b.count) / 3

--- a/Textream/Textream/SpeechRecognizer.swift
+++ b/Textream/Textream/SpeechRecognizer.swift
@@ -307,7 +307,17 @@ class SpeechRecognizer {
 
         speechRecognizer = SFSpeechRecognizer(locale: Locale(identifier: NotchSettings.shared.speechLocale))
         guard let speechRecognizer, speechRecognizer.isAvailable else {
-            error = "Speech recognizer not available"
+            // Availability is often transient (the recognition service churns
+            // briefly after a task cancellation or device change). Giving up
+            // here leaves the engine stopped and the app deaf — retry like
+            // the invalid-format guard below does.
+            if retryCount < maxRetries {
+                retryCount += 1
+                scheduleBeginRecognition(after: 0.5)
+            } else {
+                error = "Speech recognizer not available"
+                isListening = false
+            }
             return
         }
 
@@ -515,8 +525,15 @@ class SpeechRecognizer {
 
         // Start new recognition task
         guard let speechRecognizer, speechRecognizer.isAvailable else {
-            error = "Speech recognizer not available"
-            isListening = false
+            // Transient unavailability — fall back to a full session restart
+            // with retries rather than going permanently deaf.
+            if retryCount < maxRetries {
+                retryCount += 1
+                scheduleBeginRecognition(after: 0.5)
+            } else {
+                error = "Speech recognizer not available"
+                isListening = false
+            }
             return
         }
 

--- a/Textream/Textream/SpeechRecognizer.swift
+++ b/Textream/Textream/SpeechRecognizer.swift
@@ -89,10 +89,7 @@ class SpeechRecognizer {
 
     /// True when recent audio levels indicate the user is actively speaking
     var isSpeaking: Bool {
-        let recent = audioLevels.suffix(10)
-        guard !recent.isEmpty else { return false }
-        let avg = recent.reduce(0, +) / CGFloat(recent.count)
-        return avg > 0.08
+        voiceActivityDetector.isActive(at: ProcessInfo.processInfo.systemUptime)
     }
 
     private var speechRecognizer: SFSpeechRecognizer?
@@ -101,6 +98,8 @@ class SpeechRecognizer {
     private var audioEngine = AVAudioEngine()
     private var sourceText: String = ""
     private var normalizedSource: String = ""
+    private var annotationRanges: [Range<Int>] = []
+    private var voiceActivityDetector = VoiceActivityDetector()
     private var matchStartOffset: Int = 0  // char offset to start matching from
     private var retryCount: Int = 0
     private let maxRetries: Int = 10
@@ -135,7 +134,9 @@ class SpeechRecognizer {
         let collapsed = words.joined(separator: " ")
         sourceText = collapsed
         normalizedSource = Self.normalize(collapsed)
+        annotationRanges = SpeechTextAlignment.annotationRanges(in: collapsed)
         recognizedCharCount = min(preservingCharCount, collapsed.count)
+        recognizedCharCount = advancePastAnnotations(from: recognizedCharCount)
         matchStartOffset = recognizedCharCount
         recentMatchPositions = []
     }
@@ -150,9 +151,11 @@ class SpeechRecognizer {
     /// tap would let a user keep a failing availability-retry loop alive
     /// forever.
     func jumpTo(charOffset: Int) {
-        let distance = abs(charOffset - recognizedCharCount)
-        recognizedCharCount = charOffset
-        matchStartOffset = charOffset
+        let clampedOffset = max(0, min(charOffset, sourceText.count))
+        let targetOffset = advancePastAnnotations(from: clampedOffset)
+        let distance = abs(targetOffset - recognizedCharCount)
+        recognizedCharCount = targetOffset
+        matchStartOffset = targetOffset
         recentMatchPositions = []
         if isListening && (distance > 500 || !audioEngine.isRunning) {
             // Far jump, or the engine died without a config-change callback —
@@ -173,8 +176,9 @@ class SpeechRecognizer {
         let collapsed = words.joined(separator: " ")
         sourceText = collapsed
         normalizedSource = Self.normalize(collapsed)
-        recognizedCharCount = 0
-        matchStartOffset = 0
+        annotationRanges = SpeechTextAlignment.annotationRanges(in: collapsed)
+        recognizedCharCount = advancePastAnnotations(from: 0)
+        matchStartOffset = recognizedCharCount
         retryCount = 0
         recentMatchPositions = []
         error = nil
@@ -200,16 +204,25 @@ class SpeechRecognizer {
                           self.shouldListen,
                           self.sessionGeneration == generation else { return }
                     if granted {
-                        self.requestSpeechAuthAndBegin(for: generation)
+                        self.beginAfterMicrophoneAccess(for: generation)
                     } else {
                         self.failListening("Microphone access denied. Open System Settings → Privacy & Security → Microphone to allow Textream.")
                     }
                 }
             }
         case .authorized:
-            requestSpeechAuthAndBegin(for: generation)
+            beginAfterMicrophoneAccess(for: generation)
         @unknown default:
             failListening("Microphone authorization is unavailable.")
+        }
+    }
+
+    private func beginAfterMicrophoneAccess(for generation: Int) {
+        guard shouldListen, sessionGeneration == generation else { return }
+        if NotchSettings.shared.listeningMode == .wordTracking {
+            requestSpeechAuthAndBegin(for: generation)
+        } else {
+            beginRecognition()
         }
     }
 
@@ -243,6 +256,7 @@ class SpeechRecognizer {
     }
 
     private func failListening(_ message: String) {
+        voiceActivityDetector.reset()
         shouldListen = false
         isListening = false
         isStarting = false
@@ -264,6 +278,7 @@ class SpeechRecognizer {
         isListening = false
         isStarting = false
         sourceText = ""
+        annotationRanges = []
         retryCount = maxRetries
         recentMatchPositions = []
         cleanupRecognition()
@@ -273,6 +288,7 @@ class SpeechRecognizer {
         guard !sourceText.isEmpty else { return }
         cleanupRecognition()
         retryCount = 0
+        recognizedCharCount = advancePastAnnotations(from: recognizedCharCount)
         matchStartOffset = recognizedCharCount
         recentMatchPositions = []
         shouldDismiss = false
@@ -314,6 +330,7 @@ class SpeechRecognizer {
     private func cleanupRecognition() {
         cleanupRecognitionTask()
         cleanupAudioEngine()
+        voiceActivityDetector.reset()
     }
 
     /// Coalesces all delayed beginRecognition() calls into a single pending work item.
@@ -343,6 +360,7 @@ class SpeechRecognizer {
             return
         }
         let expectedSessionGeneration = sessionGeneration
+        let requiresSpeechRecognition = NotchSettings.shared.listeningMode == .wordTracking
         // Ensure clean state
         cleanupRecognition()
         guard shouldListen, sessionGeneration == expectedSessionGeneration else {
@@ -392,43 +410,48 @@ class SpeechRecognizer {
             }
         }
 
-        speechRecognizer = SFSpeechRecognizer(locale: Locale(identifier: NotchSettings.shared.speechLocale))
-        guard let speechRecognizer else {
-            // nil means the locale isn't supported for speech recognition —
-            // that's permanent, so fail immediately instead of retrying.
-            failListening("Speech recognition isn't supported for the selected language.")
-            return
-        }
-        guard speechRecognizer.isAvailable else {
-            // Unavailability is often transient (the recognition service
-            // churns briefly after a task cancellation or device change).
-            // Giving up here leaves the engine stopped and the app deaf —
-            // retry like the invalid-format guard below does.
-            if retryCount < maxRetries {
-                retryCount += 1
-                scheduleBeginRecognition(after: 0.5)
-            } else {
-                failListening("Speech recognizer is not available.")
+        if requiresSpeechRecognition {
+            speechRecognizer = SFSpeechRecognizer(locale: Locale(identifier: NotchSettings.shared.speechLocale))
+            guard let speechRecognizer else {
+                // nil means the locale isn't supported for speech recognition —
+                // that's permanent, so fail immediately instead of retrying.
+                failListening("Speech recognition isn't supported for the selected language.")
+                return
             }
-            return
-        }
+            guard speechRecognizer.isAvailable else {
+                // Unavailability is often transient (the recognition service
+                // churns briefly after a task cancellation or device change).
+                // Giving up here leaves the engine stopped and the app deaf —
+                // retry like the invalid-format guard below does.
+                if retryCount < maxRetries {
+                    retryCount += 1
+                    scheduleBeginRecognition(after: 0.5)
+                } else {
+                    failListening("Speech recognizer is not available.")
+                }
+                return
+            }
 
-        recognitionRequest = SFSpeechAudioBufferRecognitionRequest()
-        guard let recognitionRequest else {
-            failListening("Unable to create a speech recognition request.")
-            return
-        }
-        recognitionRequest.shouldReportPartialResults = true
-        recognitionRequest.taskHint = .dictation
+            recognitionRequest = SFSpeechAudioBufferRecognitionRequest()
+            guard let recognitionRequest else {
+                failListening("Unable to create a speech recognition request.")
+                return
+            }
+            recognitionRequest.shouldReportPartialResults = true
+            recognitionRequest.taskHint = .dictation
 
-        // Add contextual strings from the source text to improve STT accuracy
-        let upcoming = String(sourceText.dropFirst(matchStartOffset))
-        let contextWords = upcoming.split(separator: " ")
-            .map { String($0).lowercased().filter { $0.isLetter || $0.isNumber } }
-            .filter { $0.count >= 5 }
-        let uniqueContextWords = Array(Set(contextWords).prefix(50))
-        if !uniqueContextWords.isEmpty {
-            recognitionRequest.contextualStrings = uniqueContextWords
+            // Add contextual strings from the source text to improve STT accuracy
+            let upcoming = String(sourceText.dropFirst(matchStartOffset))
+            let contextWords = upcoming.split(separator: " ")
+                .map { String($0).lowercased().filter { $0.isLetter || $0.isNumber } }
+                .filter { $0.count >= 5 }
+            let uniqueContextWords = Array(Set(contextWords).prefix(50))
+            if !uniqueContextWords.isEmpty {
+                recognitionRequest.contextualStrings = uniqueContextWords
+            }
+        } else {
+            speechRecognizer = nil
+            recognitionRequest = nil
         }
 
         let inputNode = audioEngine.inputNode
@@ -486,64 +509,66 @@ class SpeechRecognizer {
             let level = CGFloat(min(rms * 5, 1.0))
 
             DispatchQueue.main.async {
-                self?.audioLevels.append(level)
-                if (self?.audioLevels.count ?? 0) > 30 {
-                    self?.audioLevels.removeFirst()
-                }
+                guard let self,
+                      self.shouldListen,
+                      self.sessionGeneration == expectedSessionGeneration else { return }
+                self.recordAudioLevel(level)
             }
         }
 
-        recognitionGeneration &+= 1
-        let currentRecognitionGeneration = recognitionGeneration
-        let currentGeneration = sessionGeneration
-        recognitionTask = speechRecognizer.recognitionTask(with: recognitionRequest) { [weak self] result, error in
-            guard let self else { return }
-            if let result {
-                let spoken = result.bestTranscription.formattedString
-                DispatchQueue.main.async {
-                    // Ignore stale results from a previous session
-                    guard self.sessionGeneration == currentGeneration,
-                          self.recognitionGeneration == currentRecognitionGeneration else { return }
-                    self.retryCount = 0 // Reset on success
-                    self.lastSpokenText = spoken
-                    self.matchCharacters(spoken: spoken)
-                }
-            }
-            if let error {
-                DispatchQueue.main.async {
-                    guard self.sessionGeneration == currentGeneration,
-                          self.recognitionGeneration == currentRecognitionGeneration else { return }
-                    // If recognitionRequest is nil, cleanup already ran (intentional cancel) — don't retry
-                    guard self.recognitionRequest != nil else { return }
-                    guard self.shouldListen && !self.shouldDismiss && !self.sourceText.isEmpty else {
-                        self.isListening = false
-                        self.isStarting = false
-                        return
+        if let speechRecognizer, let recognitionRequest {
+            recognitionGeneration &+= 1
+            let currentRecognitionGeneration = recognitionGeneration
+            let currentGeneration = sessionGeneration
+            recognitionTask = speechRecognizer.recognitionTask(with: recognitionRequest) { [weak self] result, error in
+                guard let self else { return }
+                if let result {
+                    let spoken = result.bestTranscription.formattedString
+                    DispatchQueue.main.async {
+                        // Ignore stale results from a previous session
+                        guard self.sessionGeneration == currentGeneration,
+                              self.recognitionGeneration == currentRecognitionGeneration else { return }
+                        self.retryCount = 0 // Reset on success
+                        self.lastSpokenText = spoken
+                        self.matchCharacters(spoken: spoken)
                     }
-
-                    self.matchStartOffset = self.recognizedCharCount
-
-                    // Distinguish timeout errors (expected every ~60s) from real errors.
-                    // SFSpeechRecognizer timeout is error code 1110 in kAFAssistantErrorDomain,
-                    // or 216 (kAudioConverterErr_FormatNotSupported). Retry immediately for
-                    // timeouts with no retry limit; use backoff for real errors.
-                    let nsError = error as NSError
-                    let isTimeout = nsError.code == 1110 || nsError.code == 216
-
-                    if isTimeout {
-                        // Expected timeout — restart immediately, no retry limit
-                        self.retryCount = 0
-                        if self.audioEngine.isRunning {
-                            self.restartTask()
-                        } else {
-                            self.scheduleBeginRecognition(after: 0.1)
+                }
+                if let error {
+                    DispatchQueue.main.async {
+                        guard self.sessionGeneration == currentGeneration,
+                              self.recognitionGeneration == currentRecognitionGeneration else { return }
+                        // If recognitionRequest is nil, cleanup already ran (intentional cancel) — don't retry
+                        guard self.recognitionRequest != nil else { return }
+                        guard self.shouldListen && !self.shouldDismiss && !self.sourceText.isEmpty else {
+                            self.isListening = false
+                            self.isStarting = false
+                            return
                         }
-                    } else if self.retryCount < self.maxRetries {
-                        self.retryCount += 1
-                        let delay = min(Double(self.retryCount) * 0.5, 1.5)
-                        self.scheduleBeginRecognition(after: delay)
-                    } else {
-                        self.failListening("Speech recognition stopped: \(error.localizedDescription)")
+
+                        self.matchStartOffset = self.recognizedCharCount
+
+                        // Distinguish timeout errors (expected every ~60s) from real errors.
+                        // SFSpeechRecognizer timeout is error code 1110 in kAFAssistantErrorDomain,
+                        // or 216 (kAudioConverterErr_FormatNotSupported). Retry immediately for
+                        // timeouts with no retry limit; use backoff for real errors.
+                        let nsError = error as NSError
+                        let isTimeout = nsError.code == 1110 || nsError.code == 216
+
+                        if isTimeout {
+                            // Expected timeout — restart immediately, no retry limit
+                            self.retryCount = 0
+                            if self.audioEngine.isRunning {
+                                self.restartTask()
+                            } else {
+                                self.scheduleBeginRecognition(after: 0.1)
+                            }
+                        } else if self.retryCount < self.maxRetries {
+                            self.retryCount += 1
+                            let delay = min(Double(self.retryCount) * 0.5, 1.5)
+                            self.scheduleBeginRecognition(after: delay)
+                        } else {
+                            self.failListening("Speech recognition stopped: \(error.localizedDescription)")
+                        }
                     }
                 }
             }
@@ -559,7 +584,9 @@ class SpeechRecognizer {
             error = nil
             isStarting = false
             isListening = true
-            startPreemptiveTimer()
+            if requiresSpeechRecognition {
+                startPreemptiveTimer()
+            }
         } catch {
             // Transient failure after a device switch — retry with longer delay
             if retryCount < maxRetries {
@@ -587,6 +614,14 @@ class SpeechRecognizer {
     }
 
     // MARK: - Thread-safe buffer appending
+
+    private func recordAudioLevel(_ level: CGFloat) {
+        audioLevels.append(level)
+        if audioLevels.count > 30 {
+            audioLevels.removeFirst()
+        }
+        voiceActivityDetector.process(level: level, at: ProcessInfo.processInfo.systemUptime)
+    }
 
     private func appendBufferToRequest(_ buffer: AVAudioPCMBuffer) {
         requestLock.lock()
@@ -757,22 +792,14 @@ class SpeechRecognizer {
         // Strategy 2: word-level match (handles STT word substitutions)
         let wordResult = wordLevelMatch(spoken: spoken)
 
-        // Use agreement-based selection instead of blind max().
-        // If both strategies agree within a tolerance, use the average.
-        // If they disagree wildly, use the more conservative (lower) result
-        // to avoid false-positive jumps.
-        let best: Int
-        let tolerance = 20 // characters
-        if abs(charResult - wordResult) <= tolerance {
-            best = (charResult + wordResult) / 2
-        } else {
-            best = min(charResult, wordResult)
-        }
+        // Combine the two strategies. When they agree, average; when they
+        // disagree, prefer the further (word-level) match so fast reading can
+        // catch up instead of being dragged back by the brittle character scan.
+        let best = SpeechTextAlignment.bestOffset(characterResult: charResult, wordResult: wordResult)
 
-        let newCount = matchStartOffset + best
-        guard newCount > recognizedCharCount else { return }
-
-        let candidate = min(newCount, sourceText.count)
+        let rawCandidate = min(matchStartOffset + best, sourceText.count)
+        let candidate = advancePastAnnotations(from: rawCandidate)
+        guard candidate > recognizedCharCount else { return }
 
         // Confidence gating: require 2-of-3 recent results to agree on
         // forward movement to avoid single-result false-positive jumps.
@@ -796,11 +823,24 @@ class SpeechRecognizer {
 
         // Small forward movements (< 1 word length) are always allowed
         // to keep the highlight responsive for normal reading
-        let smallStep = candidate - recognizedCharCount <= 15
-
-        if confirmed || smallStep {
+        if SpeechTextAlignment.shouldCommit(
+            characterResult: charResult,
+            wordResult: wordResult,
+            current: recognizedCharCount,
+            rawCandidate: rawCandidate,
+            candidate: candidate,
+            confirmed: confirmed
+        ) {
             recognizedCharCount = candidate
         }
+    }
+
+    private func advancePastAnnotations(from offset: Int) -> Int {
+        SpeechTextAlignment.advancePastAnnotations(
+            in: sourceText,
+            ranges: annotationRanges,
+            from: offset
+        )
     }
 
     private func charLevelMatch(spoken: String) -> Int {
@@ -843,8 +883,9 @@ class SpeechRecognizer {
                 // Try to re-sync: look ahead in both strings
                 var found = false
 
-                // Skip up to 3 chars in spoken (STT inserted extra chars)
-                let maxSkipR = min(3, spk.count - ri - 1)
+                // Skip up to 5 chars in spoken (STT inserted extra chars, or
+                // fast reading outran the scan)
+                let maxSkipR = min(5, spk.count - ri - 1)
                 if maxSkipR >= 1 {
                     for skipR in 1...maxSkipR {
                         let nextRI = ri + skipR
@@ -857,8 +898,9 @@ class SpeechRecognizer {
                 }
                 if found { continue }
 
-                // Skip up to 3 chars in source (STT missed some chars)
-                let maxSkipS = min(3, src.count - si - 1)
+                // Skip up to 5 chars in source (STT missed some chars, or
+                // fast reading outran the scan)
+                let maxSkipS = min(5, src.count - si - 1)
                 if maxSkipS >= 1 {
                     for skipS in 1...maxSkipS {
                         let nextSI = si + skipS
@@ -943,9 +985,10 @@ class SpeechRecognizer {
                     matchedCharCount += 1
                 }
             } else {
-                // Try skipping up to 3 spoken words (STT hallucinated words)
+                // Try skipping up to 5 spoken words (STT hallucinated words,
+                // or fast reading produced a burst)
                 var foundSpk = false
-                let maxSpkSkip = min(3, spokenWords.count - ri - 1)
+                let maxSpkSkip = min(5, spokenWords.count - ri - 1)
                 for skip in 1...max(1, maxSpkSkip) where skip <= maxSpkSkip {
                     let nextSpk = spokenWords[ri + skip].filter { $0.isLetter || $0.isNumber }
                     if srcWord == nextSpk || isFuzzyMatch(srcWord, nextSpk) {
@@ -956,9 +999,9 @@ class SpeechRecognizer {
                 }
                 if foundSpk { continue }
 
-                // Try skipping up to 3 source words (user read fast, STT missed words)
+                // Try skipping up to 5 source words (user read fast, STT missed words)
                 var foundSrc = false
-                let maxSrcSkip = min(3, sourceWords.count - si - 1)
+                let maxSrcSkip = min(5, sourceWords.count - si - 1)
                 for skip in 1...max(1, maxSrcSkip) where skip <= maxSrcSkip {
                     let nextSrc = sourceWords[si + skip].lowercased().filter { $0.isLetter || $0.isNumber }
                     if nextSrc == spkWord || isFuzzyMatch(nextSrc, spkWord) {

--- a/Textream/Textream/SpeechRecognizer.swift
+++ b/Textream/Textream/SpeechRecognizer.swift
@@ -106,6 +106,12 @@ class SpeechRecognizer {
     /// Sliding window of recent match positions for confidence gating.
     /// We require 2-of-3 recent results to agree before committing a forward jump.
     private var recentMatchPositions: [Int] = []
+    /// Chars of the running transcript to ignore when matching — set on jumps
+    /// so the task can keep running instead of being restarted (a restart
+    /// drops the audio spoken during the restart window and takes ~1s to
+    /// warm, which loses exactly the words the user re-speaks after a jump).
+    /// Reset to 0 whenever a new recognition task starts a fresh transcript.
+    private var spokenAnchor: Int = 0
 
     /// Update the source text while preserving the current recognized char count.
     /// Used by Director Mode to live-edit unread text without resetting read progress.
@@ -119,15 +125,15 @@ class SpeechRecognizer {
         recentMatchPositions = []
     }
 
-    /// Jump highlight to a specific char offset (e.g. when user taps a word)
+    /// Jump highlight to a specific char offset (e.g. when user taps a word).
+    /// Keeps the recognition task alive and anchors matching past the
+    /// already-spoken transcript.
     func jumpTo(charOffset: Int) {
         recognizedCharCount = charOffset
         matchStartOffset = charOffset
         retryCount = 0
         recentMatchPositions = []
-        if isListening {
-            restartRecognition()
-        }
+        spokenAnchor = lastSpokenText.count
     }
 
     func start(with text: String) {
@@ -266,6 +272,7 @@ class SpeechRecognizer {
     private func beginRecognition() {
         // Ensure clean state
         cleanupRecognition()
+        spokenAnchor = 0 // new session = fresh transcript
 
         // Create a fresh engine so it picks up the current hardware format.
         // AVAudioEngine caches the device format internally and reset() alone
@@ -470,6 +477,7 @@ class SpeechRecognizer {
         // Update match offset before restarting
         matchStartOffset = recognizedCharCount
         recentMatchPositions = []
+        spokenAnchor = 0 // new task = fresh transcript
 
         // Cancel any pending restart to avoid stale beginRecognition clobbering this session
         pendingRestart?.cancel()
@@ -575,7 +583,13 @@ class SpeechRecognizer {
 
     // MARK: - Fuzzy character-level matching
 
-    private func matchCharacters(spoken: String) {
+    private func matchCharacters(spoken fullSpoken: String) {
+        // Ignore transcript from before the most recent jump
+        let spoken = spokenAnchor > 0
+            ? String(fullSpoken.dropFirst(min(spokenAnchor, fullSpoken.count)))
+            : fullSpoken
+        guard !spoken.isEmpty else { return }
+
         // Strategy 1: character-level fuzzy match from the start offset
         let charResult = charLevelMatch(spoken: spoken)
 

--- a/Textream/Textream/SpeechRecognizer.swift
+++ b/Textream/Textream/SpeechRecognizer.swift
@@ -48,7 +48,10 @@ struct AudioInputDevice: Identifiable, Hashable {
             )
             var uid: CFString = "" as CFString
             var uidSize = UInt32(MemoryLayout<CFString>.size)
-            guard AudioObjectGetPropertyData(deviceID, &uidAddress, 0, nil, &uidSize, &uid) == noErr else { continue }
+            let uidStatus = withUnsafeMutablePointer(to: &uid) { uidPointer in
+                AudioObjectGetPropertyData(deviceID, &uidAddress, 0, nil, &uidSize, uidPointer)
+            }
+            guard uidStatus == noErr else { continue }
 
             // Get name
             var nameAddress = AudioObjectPropertyAddress(
@@ -58,7 +61,10 @@ struct AudioInputDevice: Identifiable, Hashable {
             )
             var name: CFString = "" as CFString
             var nameSize = UInt32(MemoryLayout<CFString>.size)
-            guard AudioObjectGetPropertyData(deviceID, &nameAddress, 0, nil, &nameSize, &name) == noErr else { continue }
+            let nameStatus = withUnsafeMutablePointer(to: &name) { namePointer in
+                AudioObjectGetPropertyData(deviceID, &nameAddress, 0, nil, &nameSize, namePointer)
+            }
+            guard nameStatus == noErr else { continue }
 
             result.append(AudioInputDevice(id: deviceID, uid: uid as String, name: name as String))
         }
@@ -74,6 +80,7 @@ struct AudioInputDevice: Identifiable, Hashable {
 class SpeechRecognizer {
     var recognizedCharCount: Int = 0
     var isListening: Bool = false
+    var isStarting: Bool = false
     var error: String?
     var audioLevels: [CGFloat] = Array(repeating: 0, count: 30)
     var lastSpokenText: String = ""
@@ -100,6 +107,8 @@ class SpeechRecognizer {
     private var configurationChangeObserver: Any?
     private var pendingRestart: DispatchWorkItem?
     private var sessionGeneration: Int = 0
+    private var recognitionGeneration: Int = 0
+    private var shouldListen: Bool = false
     private var suppressConfigChange: Bool = false
     private var requestLock = NSLock()
     private var preemptiveRestartTimer: Timer?
@@ -148,7 +157,7 @@ class SpeechRecognizer {
         if isListening && (distance > 500 || !audioEngine.isRunning) {
             // Far jump, or the engine died without a config-change callback —
             // fall back to a full restart (also refreshes contextualStrings).
-            restartRecognition()
+            restartRecognition(resetRetryCount: false)
             return
         }
         spokenAnchorPrefix = lastSpokenText
@@ -169,43 +178,53 @@ class SpeechRecognizer {
         retryCount = 0
         recentMatchPositions = []
         error = nil
-        sessionGeneration += 1
+        sessionGeneration &+= 1
+        shouldListen = true
+        isListening = false
+        isStarting = true
+        requestMicrophoneAccessAndBegin(for: sessionGeneration)
+    }
+
+    private func requestMicrophoneAccessAndBegin(for generation: Int) {
+        guard shouldListen, sessionGeneration == generation else { return }
 
         // Check microphone permission first
         switch AVCaptureDevice.authorizationStatus(for: .audio) {
         case .denied, .restricted:
-            error = "Microphone access denied. Open System Settings → Privacy & Security → Microphone to allow Textream."
+            failListening("Microphone access denied. Open System Settings → Privacy & Security → Microphone to allow Textream.")
             openMicrophoneSettings()
-            return
         case .notDetermined:
             AVCaptureDevice.requestAccess(for: .audio) { [weak self] granted in
                 DispatchQueue.main.async {
+                    guard let self,
+                          self.shouldListen,
+                          self.sessionGeneration == generation else { return }
                     if granted {
-                        self?.requestSpeechAuthAndBegin()
+                        self.requestSpeechAuthAndBegin(for: generation)
                     } else {
-                        self?.error = "Microphone access denied. Open System Settings → Privacy & Security → Microphone to allow Textream."
+                        self.failListening("Microphone access denied. Open System Settings → Privacy & Security → Microphone to allow Textream.")
                     }
                 }
             }
-            return
         case .authorized:
-            break
+            requestSpeechAuthAndBegin(for: generation)
         @unknown default:
-            break
+            failListening("Microphone authorization is unavailable.")
         }
-
-        requestSpeechAuthAndBegin()
     }
 
-    private func requestSpeechAuthAndBegin() {
+    private func requestSpeechAuthAndBegin(for generation: Int) {
         SFSpeechRecognizer.requestAuthorization { [weak self] status in
             DispatchQueue.main.async {
+                guard let self,
+                      self.shouldListen,
+                      self.sessionGeneration == generation else { return }
                 switch status {
                 case .authorized:
-                    self?.beginRecognition()
+                    self.beginRecognition()
                 default:
-                    self?.error = "Speech recognition not authorized. Open System Settings → Privacy & Security → Speech Recognition to allow Textream."
-                    self?.openSpeechRecognitionSettings()
+                    self.failListening("Speech recognition not authorized. Open System Settings → Privacy & Security → Speech Recognition to allow Textream.")
+                    self.openSpeechRecognitionSettings()
                 }
             }
         }
@@ -223,13 +242,27 @@ class SpeechRecognizer {
         }
     }
 
-    func stop() {
+    private func failListening(_ message: String) {
+        shouldListen = false
         isListening = false
+        isStarting = false
+        error = message
+        cleanupRecognition()
+    }
+
+    func stop() {
+        shouldListen = false
+        sessionGeneration &+= 1
+        isListening = false
+        isStarting = false
         cleanupRecognition()
     }
 
     func forceStop() {
+        shouldListen = false
+        sessionGeneration &+= 1
         isListening = false
+        isStarting = false
         sourceText = ""
         retryCount = maxRetries
         recentMatchPositions = []
@@ -237,14 +270,22 @@ class SpeechRecognizer {
     }
 
     func resume() {
+        guard !sourceText.isEmpty else { return }
+        cleanupRecognition()
         retryCount = 0
         matchStartOffset = recognizedCharCount
         recentMatchPositions = []
         shouldDismiss = false
-        beginRecognition()
+        error = nil
+        sessionGeneration &+= 1
+        shouldListen = true
+        isListening = false
+        isStarting = true
+        requestMicrophoneAccessAndBegin(for: sessionGeneration)
     }
 
     private func cleanupRecognitionTask() {
+        recognitionGeneration &+= 1
         // Cancel any pending restart to prevent overlapping beginRecognition calls
         pendingRestart?.cancel()
         pendingRestart = nil
@@ -279,8 +320,15 @@ class SpeechRecognizer {
     /// Any previously scheduled restart is cancelled before the new one is queued.
     private func scheduleBeginRecognition(after delay: TimeInterval) {
         pendingRestart?.cancel()
+        guard shouldListen, !sourceText.isEmpty else { return }
+        isListening = false
+        isStarting = true
+        let expectedSessionGeneration = sessionGeneration
         let work = DispatchWorkItem { [weak self] in
-            guard let self else { return }
+            guard let self,
+                  self.shouldListen,
+                  self.sessionGeneration == expectedSessionGeneration,
+                  !self.sourceText.isEmpty else { return }
             self.pendingRestart = nil
             self.beginRecognition()
         }
@@ -289,8 +337,21 @@ class SpeechRecognizer {
     }
 
     private func beginRecognition() {
+        guard shouldListen, !sourceText.isEmpty else {
+            isListening = false
+            isStarting = false
+            return
+        }
+        let expectedSessionGeneration = sessionGeneration
         // Ensure clean state
         cleanupRecognition()
+        guard shouldListen, sessionGeneration == expectedSessionGeneration else {
+            isListening = false
+            isStarting = false
+            return
+        }
+        isListening = false
+        isStarting = true
         // New session = fresh transcript (see restartTask for why
         // lastSpokenText must be cleared alongside the anchor)
         spokenAnchorPrefix = ""
@@ -300,6 +361,7 @@ class SpeechRecognizer {
         // AVAudioEngine caches the device format internally and reset() alone
         // does not reliably flush it after a mic switch.
         audioEngine = AVAudioEngine()
+        suppressConfigChange = false
 
         // Set selected microphone if configured
         let micUID = NotchSettings.shared.selectedMicUID
@@ -322,8 +384,11 @@ class SpeechRecognizer {
                 AudioUnitInitialize(audioUnit)
             }
             // Allow config changes again after a settle period
+            let expectedSessionGeneration = sessionGeneration
             DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
-                self?.suppressConfigChange = false
+                guard let self,
+                      self.sessionGeneration == expectedSessionGeneration else { return }
+                self.suppressConfigChange = false
             }
         }
 
@@ -331,8 +396,7 @@ class SpeechRecognizer {
         guard let speechRecognizer else {
             // nil means the locale isn't supported for speech recognition —
             // that's permanent, so fail immediately instead of retrying.
-            error = "Speech recognition isn't supported for the selected language"
-            isListening = false
+            failListening("Speech recognition isn't supported for the selected language.")
             return
         }
         guard speechRecognizer.isAvailable else {
@@ -344,15 +408,18 @@ class SpeechRecognizer {
                 retryCount += 1
                 scheduleBeginRecognition(after: 0.5)
             } else {
-                error = "Speech recognizer not available"
-                isListening = false
+                failListening("Speech recognizer is not available.")
             }
             return
         }
 
         recognitionRequest = SFSpeechAudioBufferRecognitionRequest()
-        guard let recognitionRequest else { return }
+        guard let recognitionRequest else {
+            failListening("Unable to create a speech recognition request.")
+            return
+        }
         recognitionRequest.shouldReportPartialResults = true
+        recognitionRequest.taskHint = .dictation
 
         // Add contextual strings from the source text to improve STT accuracy
         let upcoming = String(sourceText.dropFirst(matchStartOffset))
@@ -374,8 +441,7 @@ class SpeechRecognizer {
                 retryCount += 1
                 scheduleBeginRecognition(after: 0.5)
             } else {
-                error = "Audio input unavailable"
-                isListening = false
+                failListening("Audio input is unavailable.")
             }
             return
         }
@@ -397,7 +463,10 @@ class SpeechRecognizer {
             object: audioEngine,
             queue: .main
         ) { [weak self] _ in
-            guard let self, !self.suppressConfigChange, !self.sourceText.isEmpty else { return }
+            guard let self,
+                  self.shouldListen,
+                  !self.suppressConfigChange,
+                  !self.sourceText.isEmpty else { return }
             self.restartRecognition()
         }
 
@@ -424,6 +493,8 @@ class SpeechRecognizer {
             }
         }
 
+        recognitionGeneration &+= 1
+        let currentRecognitionGeneration = recognitionGeneration
         let currentGeneration = sessionGeneration
         recognitionTask = speechRecognizer.recognitionTask(with: recognitionRequest) { [weak self] result, error in
             guard let self else { return }
@@ -431,7 +502,8 @@ class SpeechRecognizer {
                 let spoken = result.bestTranscription.formattedString
                 DispatchQueue.main.async {
                     // Ignore stale results from a previous session
-                    guard self.sessionGeneration == currentGeneration else { return }
+                    guard self.sessionGeneration == currentGeneration,
+                          self.recognitionGeneration == currentRecognitionGeneration else { return }
                     self.retryCount = 0 // Reset on success
                     self.lastSpokenText = spoken
                     self.matchCharacters(spoken: spoken)
@@ -439,10 +511,13 @@ class SpeechRecognizer {
             }
             if let error {
                 DispatchQueue.main.async {
+                    guard self.sessionGeneration == currentGeneration,
+                          self.recognitionGeneration == currentRecognitionGeneration else { return }
                     // If recognitionRequest is nil, cleanup already ran (intentional cancel) — don't retry
                     guard self.recognitionRequest != nil else { return }
-                    guard self.isListening && !self.shouldDismiss && !self.sourceText.isEmpty else {
+                    guard self.shouldListen && !self.shouldDismiss && !self.sourceText.isEmpty else {
                         self.isListening = false
+                        self.isStarting = false
                         return
                     }
 
@@ -468,7 +543,7 @@ class SpeechRecognizer {
                         let delay = min(Double(self.retryCount) * 0.5, 1.5)
                         self.scheduleBeginRecognition(after: delay)
                     } else {
-                        self.isListening = false
+                        self.failListening("Speech recognition stopped: \(error.localizedDescription)")
                     }
                 }
             }
@@ -477,6 +552,12 @@ class SpeechRecognizer {
         do {
             audioEngine.prepare()
             try audioEngine.start()
+            guard shouldListen, sessionGeneration == expectedSessionGeneration else {
+                cleanupRecognition()
+                return
+            }
+            error = nil
+            isStarting = false
             isListening = true
             startPreemptiveTimer()
         } catch {
@@ -485,21 +566,24 @@ class SpeechRecognizer {
                 retryCount += 1
                 scheduleBeginRecognition(after: 0.5)
             } else {
-                self.error = "Audio engine failed: \(error.localizedDescription)"
-                isListening = false
+                failListening("Audio engine failed: \(error.localizedDescription)")
             }
         }
     }
 
-    private func restartRecognition() {
-        retryCount = 0
-        isListening = true
-        if audioEngine.isRunning {
-            restartTask()
-        } else {
-            cleanupRecognition()
-            scheduleBeginRecognition(after: 0.5)
+    private func restartRecognition(resetRetryCount: Bool = true) {
+        guard shouldListen, !sourceText.isEmpty else {
+            isListening = false
+            isStarting = false
+            return
         }
+        if resetRetryCount {
+            retryCount = 0
+        }
+        isListening = false
+        isStarting = true
+        cleanupRecognition()
+        scheduleBeginRecognition(after: 0.5)
     }
 
     // MARK: - Thread-safe buffer appending
@@ -513,6 +597,16 @@ class SpeechRecognizer {
     // MARK: - Soft restart (task only, keeps audio engine running)
 
     private func restartTask() {
+        guard shouldListen, isListening, audioEngine.isRunning, !sourceText.isEmpty else {
+            isListening = false
+            if shouldListen, !sourceText.isEmpty {
+                cleanupRecognition()
+                scheduleBeginRecognition(after: 0.5)
+            }
+            return
+        }
+        recognitionGeneration &+= 1
+        let currentRecognitionGeneration = recognitionGeneration
         // Update match offset before restarting
         matchStartOffset = recognizedCharCount
         recentMatchPositions = []
@@ -532,6 +626,7 @@ class SpeechRecognizer {
         // between endAudio() and the new assignment.
         let newRequest = SFSpeechAudioBufferRecognitionRequest()
         newRequest.shouldReportPartialResults = true
+        newRequest.taskHint = .dictation
 
         // Add contextual strings for the remaining text
         let upcoming = String(sourceText.dropFirst(matchStartOffset))
@@ -565,10 +660,8 @@ class SpeechRecognizer {
                 retryCount += 1
                 scheduleBeginRecognition(after: 0.5)
             } else {
-                error = "Speech recognizer not available"
-                isListening = false
                 // Don't leave the mic hot with no session consuming it
-                cleanupAudioEngine()
+                failListening("Speech recognizer is not available.")
             }
             return
         }
@@ -579,7 +672,8 @@ class SpeechRecognizer {
             if let result {
                 let spoken = result.bestTranscription.formattedString
                 DispatchQueue.main.async {
-                    guard self.sessionGeneration == currentGeneration else { return }
+                    guard self.sessionGeneration == currentGeneration,
+                          self.recognitionGeneration == currentRecognitionGeneration else { return }
                     self.retryCount = 0
                     self.lastSpokenText = spoken
                     self.matchCharacters(spoken: spoken)
@@ -587,9 +681,12 @@ class SpeechRecognizer {
             }
             if let error {
                 DispatchQueue.main.async {
+                    guard self.sessionGeneration == currentGeneration,
+                          self.recognitionGeneration == currentRecognitionGeneration else { return }
                     guard self.recognitionRequest != nil else { return }
-                    guard self.isListening && !self.shouldDismiss && !self.sourceText.isEmpty else {
+                    guard self.shouldListen && !self.shouldDismiss && !self.sourceText.isEmpty else {
                         self.isListening = false
+                        self.isStarting = false
                         return
                     }
 
@@ -610,7 +707,7 @@ class SpeechRecognizer {
                         let delay = min(Double(self.retryCount) * 0.5, 1.5)
                         self.scheduleBeginRecognition(after: delay)
                     } else {
-                        self.isListening = false
+                        self.failListening("Speech recognition stopped: \(error.localizedDescription)")
                     }
                 }
             }
@@ -720,6 +817,13 @@ class SpeechRecognizer {
             let sc = src[si]
             let rc = spk[ri]
 
+            if sc == "[",
+               let closingIndex = src[si...].firstIndex(of: "]") {
+                si = closingIndex + 1
+                lastGoodOrigIndex = si
+                continue
+            }
+
             // Skip non-alphanumeric in source
             if !sc.isLetter && !sc.isNumber {
                 si += 1
@@ -774,6 +878,19 @@ class SpeechRecognizer {
             }
         }
 
+        while si < src.count {
+            if src[si] == "[",
+               let closingIndex = src[si...].firstIndex(of: "]") {
+                si = closingIndex + 1
+                lastGoodOrigIndex = si
+            } else if !src[si].isLetter && !src[si].isNumber {
+                si += 1
+                lastGoodOrigIndex = si
+            } else {
+                break
+            }
+        }
+
         return lastGoodOrigIndex
     }
 
@@ -786,15 +903,25 @@ class SpeechRecognizer {
     private func wordLevelMatch(spoken: String) -> Int {
         let remainingSource = String(sourceText.dropFirst(matchStartOffset))
         let sourceWords = remainingSource.split(separator: " ").map { String($0) }
-        let spokenWords = spoken.lowercased().split(separator: " ").map { String($0) }
+        let spokenWords = splitTextIntoWords(spoken.lowercased())
 
         var si = 0 // source word index
         var ri = 0 // spoken word index
         var matchedCharCount = 0
+        var isInsideAnnotation = false
 
         while si < sourceWords.count && ri < spokenWords.count {
             // Auto-skip annotation words in source (brackets, emoji)
-            if Self.isAnnotationWord(sourceWords[si]) {
+            let beginsAnnotation = sourceWords[si].hasPrefix("[")
+                && sourceWords[si...].contains(where: { $0.contains("]") })
+            let skipsAnnotation = isInsideAnnotation || beginsAnnotation || Self.isAnnotationWord(sourceWords[si])
+            if skipsAnnotation {
+                if beginsAnnotation {
+                    isInsideAnnotation = true
+                }
+                if sourceWords[si].contains("]") {
+                    isInsideAnnotation = false
+                }
                 matchedCharCount += sourceWords[si].count
                 if si < sourceWords.count - 1 { matchedCharCount += 1 }
                 si += 1
@@ -859,7 +986,17 @@ class SpeechRecognizer {
         }
 
         // Auto-skip trailing annotation words at end of source
-        while si < sourceWords.count && Self.isAnnotationWord(sourceWords[si]) {
+        while si < sourceWords.count {
+            let beginsAnnotation = sourceWords[si].hasPrefix("[")
+                && sourceWords[si...].contains(where: { $0.contains("]") })
+            let skipsAnnotation = isInsideAnnotation || beginsAnnotation || Self.isAnnotationWord(sourceWords[si])
+            guard skipsAnnotation else { break }
+            if beginsAnnotation {
+                isInsideAnnotation = true
+            }
+            if sourceWords[si].contains("]") {
+                isInsideAnnotation = false
+            }
             matchedCharCount += sourceWords[si].count
             if si < sourceWords.count - 1 { matchedCharCount += 1 }
             si += 1

--- a/Textream/Textream/SpeechTextAlignment.swift
+++ b/Textream/Textream/SpeechTextAlignment.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+enum SpeechTextAlignment {
+    static func annotationFlags(for words: [String]) -> [Bool] {
+        var closingAtOrAfter = Array(repeating: false, count: words.count)
+        var hasClosing = false
+        for index in words.indices.reversed() {
+            if words[index].contains("]") {
+                hasClosing = true
+            }
+            closingAtOrAfter[index] = hasClosing
+        }
+
+        var flags: [Bool] = []
+        var isInsideAnnotation = false
+        for (index, word) in words.enumerated() {
+            let beginsAnnotation = word.hasPrefix("[") && closingAtOrAfter[index]
+            let isAnnotation = isInsideAnnotation || beginsAnnotation
+            flags.append(isAnnotation)
+            if beginsAnnotation {
+                isInsideAnnotation = true
+            }
+            if isInsideAnnotation && word.contains("]") {
+                isInsideAnnotation = false
+            }
+        }
+        return flags
+    }
+
+    static func annotationRanges(in text: String) -> [Range<Int>] {
+        var ranges: [Range<Int>] = []
+        var openingIndex: Int?
+
+        for (index, character) in text.enumerated() {
+            if character == "[" && openingIndex == nil {
+                openingIndex = index
+            } else if character == "]", let start = openingIndex {
+                ranges.append(start..<(index + 1))
+                openingIndex = nil
+            }
+        }
+
+        return ranges
+    }
+
+    static func advancePastAnnotations(
+        in text: String,
+        ranges: [Range<Int>],
+        from offset: Int
+    ) -> Int {
+        let characters = Array(text)
+        var current = max(0, min(offset, characters.count))
+        var skippedAnnotation = false
+
+        while current < characters.count {
+            if let range = ranges.first(where: { $0.contains(current) }) {
+                current = range.upperBound
+                skippedAnnotation = true
+                continue
+            }
+
+            var next = current
+            while next < characters.count && characters[next].isWhitespace {
+                next += 1
+            }
+
+            if let range = ranges.first(where: { $0.lowerBound == next }) {
+                current = range.upperBound
+                skippedAnnotation = true
+                continue
+            }
+
+            return skippedAnnotation ? next : current
+        }
+
+        return current
+    }
+
+    /// Combine the character-level and word-level match results into a single
+    /// forward offset. When they roughly agree, average them. When they
+    /// disagree, prefer the further match: the word-level scan advances
+    /// in-order and monotonically, so trusting it lets fast reading catch up
+    /// instead of being dragged back by the brittle character scan that
+    /// desyncs over long spans. `shouldCommit` still gates single-strategy
+    /// (one result is zero) jumps behind confirmation.
+    static func bestOffset(
+        characterResult: Int,
+        wordResult: Int,
+        agreementTolerance: Int = 20
+    ) -> Int {
+        if abs(characterResult - wordResult) <= agreementTolerance {
+            return (characterResult + wordResult) / 2
+        }
+        return max(characterResult, wordResult)
+    }
+
+    static func shouldCommit(
+        characterResult: Int,
+        wordResult: Int,
+        current: Int,
+        rawCandidate: Int,
+        candidate: Int,
+        confirmed: Bool
+    ) -> Bool {
+        // When both the character and word strategies independently found
+        // forward progress, trust the (conservative) match even if they land
+        // at different offsets. A false positive would require both strategies
+        // to hallucinate the same advance, which is unlikely — so this keeps
+        // multi-word phrases (e.g. "following your voice") responsive without
+        // waiting for a streaming partial to repeat the same position.
+        let bothProgressed = min(characterResult, wordResult) > 0
+        // A single strategy matching forward is riskier, so it still needs
+        // either a small step or confirmation from repeated results.
+        let skippedAnnotation = candidate > rawCandidate
+        let smallStep = candidate - current <= 15
+        return bothProgressed || skippedAnnotation || confirmed || smallStep
+    }
+}

--- a/Textream/Textream/TextDirection.swift
+++ b/Textream/Textream/TextDirection.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+enum TextBaseDirection: Equatable {
+    case leftToRight
+    case rightToLeft
+    case natural
+}
+
+/// Infers the base direction from the first strong alphabetic character,
+/// ignoring bracketed teleprompter cues such as `[pause]`.
+func textBaseDirection(in text: String) -> TextBaseDirection {
+    var isInsideAnnotation = false
+
+    for scalar in text.unicodeScalars {
+        if scalar == "[" {
+            isInsideAnnotation = true
+            continue
+        }
+        if scalar == "]", isInsideAnnotation {
+            isInsideAnnotation = false
+            continue
+        }
+        guard !isInsideAnnotation, scalar.properties.isAlphabetic else { continue }
+        return isRightToLeftScript(scalar) ? .rightToLeft : .leftToRight
+    }
+
+    return .natural
+}
+
+private func isRightToLeftScript(_ scalar: Unicode.Scalar) -> Bool {
+    switch scalar.value {
+    case 0x0590...0x05FF,   // Hebrew
+         0x0600...0x06FF,   // Arabic
+         0x0700...0x074F,   // Syriac
+         0x0750...0x077F,   // Arabic Supplement
+         0x0780...0x07BF,   // Thaana
+         0x07C0...0x07FF,   // NKo
+         0x0800...0x083F,   // Samaritan
+         0x0840...0x085F,   // Mandaic
+         0x0870...0x089F,   // Arabic Extended-B
+         0x08A0...0x08FF,   // Arabic Extended-A
+         0xFB50...0xFDFF,   // Arabic Presentation Forms-A
+         0xFE70...0xFEFF,   // Arabic Presentation Forms-B
+         0x1E800...0x1E8DF, // Mende Kikakui
+         0x1E900...0x1E95F, // Adlam
+         0x1EE00...0x1EEFF: // Arabic Mathematical Alphabetic Symbols
+        return true
+    default:
+        return false
+    }
+}

--- a/Textream/Textream/TextDirection.swift
+++ b/Textream/Textream/TextDirection.swift
@@ -27,6 +27,158 @@ func textBaseDirection(in text: String) -> TextBaseDirection {
     return .natural
 }
 
+/// Infers the base direction from whichever script dominates the text, ignoring
+/// bracketed teleprompter cues such as `[pause]`.
+///
+/// First-strong detection is the Unicode default, but it misreads a script that
+/// happens to open with a Latin product name, quote, or speaker label — a single
+/// leading "Textream" would lay an entire Hebrew script out left-to-right. Scripts
+/// are read whole, so the dominant script is the better signal for a whole page.
+func dominantBaseDirection(in text: String) -> TextBaseDirection {
+    var rightToLeftCount = 0
+    var leftToRightCount = 0
+    var isInsideAnnotation = false
+
+    for scalar in text.unicodeScalars {
+        if scalar == "[" {
+            isInsideAnnotation = true
+            continue
+        }
+        if scalar == "]", isInsideAnnotation {
+            isInsideAnnotation = false
+            continue
+        }
+        guard !isInsideAnnotation, scalar.properties.isAlphabetic else { continue }
+        if isRightToLeftScript(scalar) {
+            rightToLeftCount += 1
+        } else {
+            leftToRightCount += 1
+        }
+    }
+
+    if rightToLeftCount == 0 && leftToRightCount == 0 { return .natural }
+    return rightToLeftCount > leftToRightCount ? .rightToLeft : .leftToRight
+}
+
+// MARK: - Word-level bidi ordering
+
+/// The bidi character type of a display token, reduced to what word-granularity
+/// reordering needs.
+enum WordDirectionClass {
+    case rightToLeft
+    case leftToRight
+    /// Punctuation, dashes, emoji — takes its direction from its neighbours.
+    case neutral
+}
+
+/// Classifies a word by its first strong character. Digit-only tokens count as
+/// left-to-right because European numbers always resolve to an even (LTR)
+/// embedding level, even inside right-to-left text.
+func wordDirectionClass(_ word: String) -> WordDirectionClass {
+    var sawNumber = false
+
+    for scalar in word.unicodeScalars {
+        if scalar.properties.isAlphabetic {
+            return isRightToLeftScript(scalar) ? .rightToLeft : .leftToRight
+        }
+        if !sawNumber, Character(scalar).isNumber {
+            sawNumber = true
+        }
+    }
+
+    return sawNumber ? .leftToRight : .neutral
+}
+
+/// One word placed in visual order, carrying the direction of the run it landed in.
+struct BidiOrderedWord<Element> {
+    let element: Element
+    /// True when the word sits in a right-to-left run and should resolve its own
+    /// punctuation and bracket mirroring right-to-left.
+    let isRightToLeft: Bool
+}
+
+/// Reorders one line of words from logical order into visual (left-to-right)
+/// order using the Unicode Bidirectional Algorithm's reordering rule (UBA L2),
+/// applied at word granularity.
+///
+/// Laying words out with a flipped `layoutDirection` reverses *every* word on the
+/// line, which also reverses embedded left-to-right runs — "Claude Code" inside a
+/// Hebrew sentence renders as "Code Claude". Resolving embedding levels and
+/// reversing only the runs that need it keeps embedded runs in reading order.
+func bidiVisualOrder<Element>(
+    _ words: [Element],
+    baseIsRightToLeft: Bool,
+    classify: (Element) -> WordDirectionClass
+) -> [BidiOrderedWord<Element>] {
+    guard !words.isEmpty else { return [] }
+
+    let baseLevel = baseIsRightToLeft ? 1 : 0
+
+    // Strong (and numeric) words get their level directly; neutrals stay unresolved.
+    var levels: [Int?] = words.map { word in
+        switch classify(word) {
+        case .rightToLeft: return 1
+        case .leftToRight: return baseIsRightToLeft ? 2 : 0
+        case .neutral: return nil
+        }
+    }
+
+    // A run of neutrals between two matching levels joins them; otherwise it
+    // falls back to the base level.
+    var index = 0
+    while index < levels.count {
+        guard levels[index] == nil else {
+            index += 1
+            continue
+        }
+        var end = index
+        while end < levels.count, levels[end] == nil { end += 1 }
+
+        let before = index > 0 ? levels[index - 1] : nil
+        let after = end < levels.count ? levels[end] : nil
+        let resolved = (before != nil && before == after) ? before! : baseLevel
+
+        for neutral in index..<end { levels[neutral] = resolved }
+        index = end
+    }
+
+    let resolvedLevels = levels.map { $0 ?? baseLevel }
+    var order = Array(words.indices)
+
+    // UBA L2: from the highest level down to the lowest odd level, reverse every
+    // contiguous run sitting at or above that level.
+    if let lowestOddLevel = resolvedLevels.filter({ $0 % 2 == 1 }).min() {
+        let highestLevel = resolvedLevels.max() ?? baseLevel
+        var level = highestLevel
+        while level >= lowestOddLevel {
+            var start = 0
+            while start < order.count {
+                guard resolvedLevels[order[start]] >= level else {
+                    start += 1
+                    continue
+                }
+                var end = start
+                while end < order.count, resolvedLevels[order[end]] >= level { end += 1 }
+                order[start..<end].reverse()
+                start = end
+            }
+            level -= 1
+        }
+    }
+
+    return order.map {
+        BidiOrderedWord(element: words[$0], isRightToLeft: resolvedLevels[$0] % 2 == 1)
+    }
+}
+
+/// Wraps a word in a Unicode directional isolate so its own punctuation, digits
+/// and bracket mirroring resolve against the run it belongs to rather than
+/// against the surrounding layout direction.
+func directionIsolated(_ word: String, isRightToLeft: Bool) -> String {
+    let isolate = isRightToLeft ? "\u{2067}" : "\u{2066}" // RLI / LRI
+    return isolate + word + "\u{2069}" // PDI
+}
+
 private func isRightToLeftScript(_ scalar: Unicode.Scalar) -> Bool {
     switch scalar.value {
     case 0x0590...0x05FF,   // Hebrew

--- a/Textream/Textream/TextreamService.swift
+++ b/Textream/Textream/TextreamService.swift
@@ -129,7 +129,10 @@ class TextreamService: NSObject, ObservableObject {
         // Unmute after new page content is loaded
         if wasListening {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
-                self?.overlayController.speechRecognizer.resume()
+                guard let recognizer = self?.overlayController.speechRecognizer,
+                      !recognizer.isListening,
+                      !recognizer.isStarting else { return }
+                recognizer.resume()
             }
         }
     }

--- a/Textream/Textream/VoiceActivityDetector.swift
+++ b/Textream/Textream/VoiceActivityDetector.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+struct VoiceActivityDetector {
+    private let activationLevel: CGFloat
+    private let immediateActivationLevel: CGFloat
+    private let requiredActiveFrames: Int
+    private let hangoverDuration: TimeInterval
+    private var consecutiveActiveFrames = 0
+    private var activeUntil = -TimeInterval.infinity
+
+    init(
+        activationLevel: CGFloat = 0.012,
+        immediateActivationLevel: CGFloat = 0.04,
+        requiredActiveFrames: Int = 2,
+        hangoverDuration: TimeInterval = 0.75
+    ) {
+        self.activationLevel = activationLevel
+        self.immediateActivationLevel = immediateActivationLevel
+        self.requiredActiveFrames = requiredActiveFrames
+        self.hangoverDuration = hangoverDuration
+    }
+
+    mutating func process(level: CGFloat, at timestamp: TimeInterval) {
+        if level >= immediateActivationLevel {
+            consecutiveActiveFrames = requiredActiveFrames
+            extendActivity(at: timestamp)
+        } else if level >= activationLevel {
+            consecutiveActiveFrames += 1
+            if consecutiveActiveFrames >= requiredActiveFrames {
+                extendActivity(at: timestamp)
+            }
+        } else {
+            consecutiveActiveFrames = 0
+        }
+    }
+
+    func isActive(at timestamp: TimeInterval) -> Bool {
+        timestamp < activeUntil
+    }
+
+    mutating func reset() {
+        consecutiveActiveFrames = 0
+        activeUntil = -TimeInterval.infinity
+    }
+
+    private mutating func extendActivity(at timestamp: TimeInterval) {
+        activeUntil = max(activeUntil, timestamp + hangoverDuration)
+    }
+}

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,0 @@
-textream.fka.dev

--- a/docs/index.html
+++ b/docs/index.html
@@ -1751,6 +1751,444 @@
       color: var(--text2);
     }
 
+    /* Director Mode Section */
+    .director-section {
+      padding: 40px 0 80px;
+    }
+
+    .director-section h2 {
+      text-align: center;
+      font-size: 32px;
+      font-weight: 700;
+      letter-spacing: -0.02em;
+      margin-bottom: 12px;
+    }
+
+    .director-section .section-sub {
+      text-align: center;
+      font-size: 16px;
+      color: var(--text2);
+      margin-bottom: 48px;
+    }
+
+    .director-demo {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 48px;
+      max-width: 760px;
+      margin: 0 auto;
+    }
+
+    .director-demo-arrow {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 6px;
+      flex-shrink: 0;
+    }
+
+    .director-demo-arrow svg {
+      width: 48px;
+      height: 24px;
+      stroke: var(--accent2);
+      fill: none;
+      stroke-width: 2;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      opacity: 0.5;
+    }
+
+    .director-demo-arrow span {
+      font-size: 11px;
+      font-weight: 600;
+      color: var(--text3);
+      white-space: nowrap;
+    }
+
+    /* Phone frame */
+    .director-phone {
+      width: 200px;
+      min-width: 200px;
+      aspect-ratio: 9 / 16;
+      background: linear-gradient(180deg, #1a1a1e 0%, #111113 100%);
+      border-radius: 28px;
+      border: 2px solid rgba(255,255,255,0.12);
+      overflow: hidden;
+      box-shadow: 0 20px 60px rgba(0,0,0,0.5);
+      position: relative;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .director-phone .phone-notch {
+      width: 60px;
+      height: 20px;
+      background: #000;
+      border-radius: 0 0 14px 14px;
+      margin: 0 auto;
+      position: relative;
+      z-index: 5;
+    }
+
+    .director-phone .phone-home {
+      position: absolute;
+      bottom: 6px;
+      left: 50%;
+      transform: translateX(-50%);
+      width: 48px;
+      height: 4px;
+      border-radius: 2px;
+      background: rgba(255,255,255,0.2);
+      z-index: 5;
+    }
+
+    .director-phone-content {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      padding: 4px 10px 16px;
+      overflow: hidden;
+    }
+
+    .dp-header {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      padding: 4px 0 6px;
+      flex-shrink: 0;
+    }
+
+    .dp-header .dp-icon {
+      width: 14px;
+      height: 14px;
+      border-radius: 3px;
+      background: linear-gradient(135deg, var(--accent1), var(--accent2));
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .dp-header .dp-icon svg {
+      width: 8px;
+      height: 8px;
+      fill: #fff;
+      stroke: none;
+    }
+
+    .dp-header span {
+      font-size: 9px;
+      font-weight: 700;
+      color: rgba(255,255,255,0.6);
+      letter-spacing: 0.02em;
+    }
+
+    .dp-editor {
+      flex: 1;
+      background: rgba(255,255,255,0.03);
+      border: 1px solid rgba(255,255,255,0.06);
+      border-radius: 8px;
+      padding: 8px;
+      overflow: hidden;
+      position: relative;
+    }
+
+    .dp-line {
+      height: 5px;
+      border-radius: 2px;
+      margin-bottom: 5px;
+      transition: background 0.3s ease, width 0.4s ease;
+    }
+
+    .dp-line.typing {
+      animation: dpType 0.6s ease-out forwards;
+    }
+
+    @keyframes dpType {
+      0% { width: 0; }
+      100% { width: var(--tw); }
+    }
+
+    .dp-line.read {
+      background: rgba(250, 204, 21, 0.25) !important;
+    }
+
+    .dp-line.current {
+      position: relative;
+    }
+
+    .dp-line.current::after {
+      content: '';
+      position: absolute;
+      top: -1px;
+      right: -1px;
+      width: 2px;
+      height: 7px;
+      background: #facc15;
+      border-radius: 1px;
+      animation: dpBlink 0.8s step-end infinite;
+    }
+
+    @keyframes dpBlink {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0; }
+    }
+
+    .dp-divider {
+      height: 1px;
+      background: linear-gradient(to right, #facc15, transparent);
+      margin: 2px 0 4px;
+      opacity: 0;
+      transition: opacity 0.3s ease;
+    }
+
+    .dp-divider.visible { opacity: 1; }
+
+    .dp-controls {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      padding: 6px 0 0;
+      flex-shrink: 0;
+    }
+
+    .dp-go-btn {
+      height: 22px;
+      border-radius: 6px;
+      padding: 0 12px;
+      font-size: 8px;
+      font-weight: 700;
+      color: #fff;
+      background: #22c55e;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: background 0.3s ease;
+    }
+
+    .dp-go-btn.stop { background: #ef4444; }
+
+    .dp-waveform {
+      display: flex;
+      align-items: center;
+      gap: 1px;
+      height: 14px;
+      flex: 1;
+      justify-content: flex-end;
+    }
+
+    .dp-waveform .dp-bar {
+      width: 2px;
+      border-radius: 1px;
+      min-height: 2px;
+      background: rgba(255,255,255,0.08);
+      transition: height 0.08s ease, background 0.15s ease;
+      align-self: center;
+    }
+
+    .dp-waveform .dp-bar.active {
+      background: rgba(250, 204, 21, 0.6);
+    }
+
+    .dp-mic {
+      width: 14px;
+      height: 14px;
+      border-radius: 50%;
+      background: rgba(255,255,255,0.06);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+    }
+
+    .dp-mic.on { background: rgba(250, 204, 21, 0.15); }
+
+    .dp-mic svg {
+      width: 7px;
+      height: 7px;
+      fill: rgba(255, 214, 10, 0.7);
+    }
+
+    /* Mac mini frame for director */
+    .director-mac {
+      width: 280px;
+      min-width: 240px;
+      aspect-ratio: 16 / 10;
+      background: linear-gradient(180deg, #1a1a1e 0%, #111113 100%);
+      border-radius: 12px;
+      border: 1px solid rgba(255,255,255,0.08);
+      overflow: hidden;
+      box-shadow: 0 16px 50px rgba(0,0,0,0.4);
+      position: relative;
+    }
+
+    .dm-camera {
+      position: absolute;
+      top: 5px;
+      left: 50%;
+      transform: translateX(-50%);
+      z-index: 20;
+    }
+
+    .dm-camera .lens {
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: radial-gradient(circle at 35% 35%, #3a3a3e 0%, #1a1a1c 60%, #0a0a0c 100%);
+      border: 1px solid rgba(255,255,255,0.08);
+    }
+
+    .dm-desktop {
+      position: absolute;
+      inset: 0;
+      background: #202124;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .dm-desktop-lines {
+      width: 70%;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .dm-desktop-lines div {
+      height: 4px;
+      border-radius: 2px;
+      background: rgba(255,255,255,0.05);
+    }
+
+    .dm-desktop-lines div:nth-child(1) { width: 60%; }
+    .dm-desktop-lines div:nth-child(2) { width: 80%; }
+    .dm-desktop-lines div:nth-child(3) { width: 50%; }
+    .dm-desktop-lines div:nth-child(4) { width: 70%; }
+
+    .dm-overlay {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 6px;
+      opacity: 0;
+      transition: opacity 0.5s ease;
+      z-index: 5;
+    }
+
+    .dm-overlay.visible { opacity: 1; }
+
+    .dm-overlay .dm-qr {
+      width: 48px;
+      height: 48px;
+      background: #fff;
+      border-radius: 6px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .dm-overlay .dm-qr svg {
+      width: 36px;
+      height: 36px;
+      fill: #000;
+    }
+
+    .dm-overlay span {
+      font-size: 7px;
+      font-weight: 600;
+      color: rgba(255,255,255,0.4);
+    }
+
+    /* Notch on the director mac */
+    .dm-notch {
+      position: absolute;
+      top: 0;
+      left: 50%;
+      transform: translateX(-50%);
+      z-index: 10;
+      overflow: hidden;
+      transition: width 0.5s cubic-bezier(0.4,0,0.2,1), height 0.5s cubic-bezier(0.4,0,0.2,1);
+    }
+
+    .dm-notch svg.dm-notch-shape {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+    }
+
+    .dm-notch-words {
+      position: relative;
+      z-index: 2;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 2px 3px;
+      padding: 14px 10px 4px;
+      height: 100%;
+      overflow: hidden;
+      -webkit-mask-image: linear-gradient(to bottom, transparent 0%, #000 16%, #000 78%, transparent 100%);
+      mask-image: linear-gradient(to bottom, transparent 0%, #000 16%, #000 78%, transparent 100%);
+      opacity: 0;
+      transition: opacity 0.3s ease;
+    }
+
+    .dm-notch-words.visible { opacity: 1; }
+
+    .dm-notch-words span {
+      font-size: 7px;
+      font-weight: 600;
+      color: rgba(255,255,255,1);
+      transition: color 0.15s ease;
+      white-space: nowrap;
+    }
+
+    .dm-notch-words span.dm-read { color: rgba(255,255,255,0.3); }
+    .dm-notch-words span.dm-current { color: rgba(255,255,255,0.6); text-decoration: underline; text-underline-offset: 2px; }
+
+    .director-labels {
+      display: flex;
+      justify-content: center;
+      gap: 48px;
+      margin-top: 20px;
+    }
+
+    .director-labels .dl-item {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    .director-labels .dl-dot {
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+    }
+
+    .director-labels .dl-item span {
+      font-size: 12px;
+      font-weight: 600;
+    }
+
+    .director-footer {
+      text-align: center;
+      margin-top: 32px;
+    }
+
+    .director-footer p {
+      font-size: 14px;
+      color: var(--text3);
+      line-height: 1.7;
+    }
+
+    .director-footer strong {
+      color: var(--text2);
+    }
+
     /* Responsive */
     @media (max-width: 600px) {
       .hero { padding: 60px 0 30px; }
@@ -1766,6 +2204,11 @@
       .fs-notch-words { padding: 20px 18px 8px; gap: 3px 5px; }
       .features-list { grid-template-columns: 1fr; }
       .feat-item:nth-child(odd) { border-right: none; }
+      .director-section h2 { font-size: 26px; }
+      .director-demo { flex-direction: column; gap: 24px; }
+      .director-demo-arrow { transform: rotate(90deg); }
+      .director-phone { width: 180px; min-width: 180px; }
+      .director-mac { width: 100%; min-width: unset; }
     }
   </style>
 </head>
@@ -2578,6 +3021,10 @@
           <div class="feat-text"><h3>Remote Connection</h3><p>View your teleprompter on any device — phone, tablet, or another computer. Scan a QR code, open in any browser. Real-time sync over your local network.</p></div>
         </div>
         <div class="feat-item">
+          <div class="feat-dot"><svg viewBox="0 0 24 24"><path d="M21.5 2v6h-6M2.5 22v-6h6M2 11.5a10 10 0 0 1 18.8-4.3M22 12.5a10 10 0 0 1-18.8 4.2"/></svg></div>
+          <div class="feat-text"><h3>Director Mode</h3><p>Let someone else control your teleprompter remotely. A director writes and pushes scripts from any browser. Read text locks, unread stays editable.</p></div>
+        </div>
+        <div class="feat-item">
           <div class="feat-dot"><svg viewBox="0 0 24 24"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg></div>
           <div class="feat-text"><h3>Live Voice Waveform</h3><p>Real-time waveform and progress bar show your voice activity so you always know the mic is working.</p></div>
         </div>
@@ -2623,6 +3070,260 @@
         </div>
       </div>
     </section>
+
+    <!-- Director Mode -->
+    <section class="director-section">
+      <h2>Hand the script to a director</h2>
+      <p class="section-sub">Someone else writes. You read. The teleprompter follows along in real time.</p>
+      <div class="director-demo">
+        <!-- Phone: Director UI -->
+        <div class="director-phone" id="dirPhone">
+          <div class="phone-notch"></div>
+          <div class="phone-home"></div>
+          <div class="director-phone-content">
+            <div class="dp-header">
+              <div class="dp-icon"><svg viewBox="0 0 24 24"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg></div>
+              <span>Textream Director</span>
+            </div>
+            <div class="dp-editor" id="dpEditor"></div>
+            <div class="dp-divider" id="dpDivider"></div>
+            <div class="dp-controls">
+              <div class="dp-go-btn" id="dpGoBtn">GO</div>
+              <div class="dp-waveform" id="dpWaveform"></div>
+              <div class="dp-mic" id="dpMic"><svg viewBox="0 0 24 24"><path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"/></svg></div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Arrow -->
+        <div class="director-demo-arrow">
+          <svg viewBox="0 0 48 24"><line x1="4" y1="12" x2="40" y2="12"/><polyline points="34 6 40 12 34 18"/></svg>
+          <span>Wi-Fi</span>
+        </div>
+
+        <!-- Mac: Notch overlay -->
+        <div class="director-mac" id="dirMac">
+          <div class="dm-camera"><div class="lens"></div></div>
+          <div class="dm-desktop">
+            <div class="dm-desktop-lines"><div></div><div></div><div></div><div></div></div>
+          </div>
+          <div class="dm-overlay visible" id="dmOverlay">
+            <div class="dm-qr">
+              <svg viewBox="0 0 24 24"><rect x="2" y="2" width="8" height="8" rx="1" fill="#000"/><rect x="14" y="2" width="8" height="8" rx="1" fill="#000"/><rect x="2" y="14" width="8" height="8" rx="1" fill="#000"/><rect x="4" y="4" width="4" height="4" rx="0.5" fill="#fff"/><rect x="16" y="4" width="4" height="4" rx="0.5" fill="#fff"/><rect x="4" y="16" width="4" height="4" rx="0.5" fill="#fff"/><rect x="14" y="14" width="3" height="3" fill="#000"/><rect x="19" y="14" width="3" height="3" fill="#000"/><rect x="14" y="19" width="3" height="3" fill="#000"/><rect x="19" y="19" width="3" height="3" fill="#000"/></svg>
+            </div>
+            <span>Director Mode</span>
+          </div>
+          <div class="dm-notch" id="dmNotch">
+            <svg class="dm-notch-shape" id="dmNotchSvg" preserveAspectRatio="none"><path id="dmNotchPath" fill="#000"/></svg>
+            <div class="dm-notch-words" id="dmNotchWords"></div>
+          </div>
+        </div>
+      </div>
+
+      <div class="director-labels">
+        <div class="dl-item"><div class="dl-dot" style="background:var(--accent2);box-shadow:0 0 4px rgba(79,139,255,0.5)"></div><span style="color:var(--accent2)">Director's Phone</span></div>
+        <div class="dl-item"><div class="dl-dot" style="background:#facc15;box-shadow:0 0 4px rgba(250,204,21,0.5)"></div><span style="color:rgba(250,204,21,0.7)">Your Mac</span></div>
+      </div>
+
+      <div class="director-footer">
+        <p><strong>Enable in Settings &rarr; Director</strong> &mdash; scan the QR code from any phone or tablet &mdash; type a script, hit Go.<br>Word tracking starts automatically. Read text locks. Unread text stays editable.</p>
+      </div>
+    </section>
+
+    <script>
+    (function() {
+      var editor = document.getElementById('dpEditor');
+      var goBtn = document.getElementById('dpGoBtn');
+      var divider = document.getElementById('dpDivider');
+      var waveform = document.getElementById('dpWaveform');
+      var mic = document.getElementById('dpMic');
+      var overlay = document.getElementById('dmOverlay');
+      var notch = document.getElementById('dmNotch');
+      var notchSvg = document.getElementById('dmNotchSvg');
+      var notchPath = document.getElementById('dmNotchPath');
+      var notchWords = document.getElementById('dmNotchWords');
+
+      var lineWidths = ['85%','70%','90%','60%','80%','75%','65%','88%'];
+      var lineColors = ['rgba(255,255,255,0.12)','rgba(255,255,255,0.10)','rgba(255,255,255,0.11)','rgba(255,255,255,0.09)','rgba(255,255,255,0.12)','rgba(255,255,255,0.10)','rgba(255,255,255,0.11)','rgba(255,255,255,0.09)'];
+      var scriptWords = 'Welcome everyone to today\'s live stream We have some exciting announcements to share with you First let me tell you about our new product launch'.split(' ');
+
+      // Build waveform bars
+      for (var i = 0; i < 20; i++) {
+        var bar = document.createElement('div');
+        bar.className = 'dp-bar';
+        bar.style.height = '2px';
+        waveform.appendChild(bar);
+      }
+
+      // Notch shape helper
+      function notchShapePath(w, h, t, br) {
+        return 'M 0,0 Q '+t+',0 '+t+','+t+' L '+t+','+(h-br)+' Q '+t+','+h+' '+(t+br)+','+h+' L '+(w-t-br)+','+h+' Q '+(w-t)+','+h+' '+(w-t)+','+(h-br)+' L '+(w-t)+','+t+' Q '+(w-t)+',0 '+w+',0 Z';
+      }
+
+      var collW = 60, collH = 12, collT = 3, collBR = 4;
+      var expW = 180, expH = 80, expT = 7, expBR = 8;
+
+      function setNotchSize(w, h, t, br) {
+        notch.style.width = w + 'px';
+        notch.style.height = h + 'px';
+        notchSvg.setAttribute('viewBox', '0 0 ' + w + ' ' + h);
+        notchPath.setAttribute('d', notchShapePath(w, h, t, br));
+      }
+
+      function animateNotch(fromW, fromH, fromT, fromBR, toW, toH, toT, toBR, dur, cb) {
+        var t0 = performance.now();
+        function step(now) {
+          var p = Math.min((now - t0) / dur, 1);
+          var ease = p < 0.5 ? 4*p*p*p : 1 - Math.pow(-2*p+2,3)/2;
+          setNotchSize(
+            fromW + (toW-fromW)*ease,
+            fromH + (toH-fromH)*ease,
+            fromT + (toT-fromT)*ease,
+            fromBR + (toBR-fromBR)*ease
+          );
+          if (p < 1) requestAnimationFrame(step);
+          else if (cb) cb();
+        }
+        requestAnimationFrame(step);
+      }
+
+      // Build notch words
+      function buildNotchWords() {
+        notchWords.innerHTML = '';
+        scriptWords.forEach(function(w) {
+          var s = document.createElement('span');
+          s.textContent = w;
+          notchWords.appendChild(s);
+        });
+      }
+
+      var waveInterval;
+
+      function startWave() {
+        var bars = waveform.querySelectorAll('.dp-bar');
+        waveInterval = setInterval(function() {
+          bars.forEach(function(bar) {
+            bar.style.height = Math.max(2, Math.random() * 12) + 'px';
+            bar.classList.add('active');
+          });
+        }, 100);
+      }
+
+      function stopWave() {
+        clearInterval(waveInterval);
+        waveform.querySelectorAll('.dp-bar').forEach(function(bar) {
+          bar.style.height = '2px';
+          bar.classList.remove('active');
+        });
+      }
+
+      function runDirectorCycle() {
+        // Reset
+        editor.innerHTML = '';
+        goBtn.textContent = 'GO';
+        goBtn.classList.remove('stop');
+        divider.classList.remove('visible');
+        overlay.classList.add('visible');
+        mic.classList.remove('on');
+        notchWords.classList.remove('visible');
+        setNotchSize(collW, collH, collT, collBR);
+        buildNotchWords();
+        stopWave();
+
+        // Phase 1: Type lines (simulated)
+        var typeDelay = 400;
+        lineWidths.forEach(function(w, i) {
+          setTimeout(function() {
+            var line = document.createElement('div');
+            line.className = 'dp-line typing';
+            line.style.setProperty('--tw', w);
+            line.style.background = lineColors[i % lineColors.length];
+            line.style.width = '0';
+            editor.appendChild(line);
+          }, typeDelay + i * 300);
+        });
+
+        // Phase 2: Press Go
+        var goTime = typeDelay + lineWidths.length * 300 + 500;
+        setTimeout(function() {
+          goBtn.textContent = 'STOP';
+          goBtn.classList.add('stop');
+          overlay.classList.remove('visible');
+          mic.classList.add('on');
+
+          // Expand notch
+          animateNotch(collW, collH, collT, collBR, expW, expH, expT, expBR, 500, function() {
+            notchWords.classList.add('visible');
+          });
+
+          startWave();
+        }, goTime);
+
+        // Phase 3: Highlight lines + notch words
+        var readTime = goTime + 800;
+        var lines = [];
+        var totalLines = lineWidths.length;
+        var wordPerLine = Math.ceil(scriptWords.length / totalLines);
+
+        for (var li = 0; li < totalLines; li++) {
+          (function(idx) {
+            setTimeout(function() {
+              lines = editor.querySelectorAll('.dp-line');
+              // Mark previous lines as read
+              for (var j = 0; j < idx; j++) {
+                if (lines[j]) lines[j].classList.add('read');
+                if (lines[j]) lines[j].classList.remove('current');
+              }
+              // Current line
+              if (lines[idx]) {
+                lines[idx].classList.add('current');
+                divider.classList.add('visible');
+              }
+
+              // Notch words
+              var notchSpans = notchWords.querySelectorAll('span');
+              var wordIdx = idx * wordPerLine;
+              for (var w = 0; w < notchSpans.length; w++) {
+                if (w < wordIdx) {
+                  notchSpans[w].className = 'dm-read';
+                } else if (w === wordIdx) {
+                  notchSpans[w].className = 'dm-current';
+                } else {
+                  notchSpans[w].className = '';
+                }
+              }
+            }, readTime + idx * 600);
+          })(li);
+        }
+
+        // Phase 4: Done — collapse
+        var doneTime = readTime + totalLines * 600 + 800;
+        setTimeout(function() {
+          stopWave();
+          mic.classList.remove('on');
+          notchWords.classList.remove('visible');
+          divider.classList.remove('visible');
+
+          // Mark all read
+          var allLines = editor.querySelectorAll('.dp-line');
+          allLines.forEach(function(l) { l.classList.add('read'); l.classList.remove('current'); });
+
+          animateNotch(expW, expH, expT, expBR, collW, collH, collT, collBR, 400, function() {
+            overlay.classList.add('visible');
+          });
+
+          goBtn.textContent = 'GO';
+          goBtn.classList.remove('stop');
+        }, doneTime);
+
+        // Phase 5: Loop
+        setTimeout(function() { runDirectorCycle(); }, doneTime + 2000);
+      }
+
+      setNotchSize(collW, collH, collT, collBR);
+      runDirectorCycle();
+    })();
+    </script>
 
     <!-- How it works -->
     <section class="how-it-works">


### PR DESCRIPTION
Reading a Hebrew script in the teleprompter is currently not usable. There is partial RTL support already (`TextDirection.swift`, the `layoutDirection` flip in `WordFlowLayout`), but it breaks down in four independent ways.

### 1. Word spacing collapses entirely

`WordFlowLayout` spaces words by appending a trailing space to each `Text` (`Text(item.word + " ")`). Text layout trims trailing whitespace when measuring, so in an RTL line every gap measures zero and the whole line renders as one unbroken string:

```
before:  ברוכיםהבאיםלטקסטרים!זהוהטלפרומפטרהאישישלך
after:   ברוכים הבאים לטקסטרים! זהו הטלפרומפטר האישי שלך
```

Words are now spaced by the enclosing `HStack` instead, which is direction-agnostic. LTR output is unchanged.

### 2. Embedded LTR runs render reversed

Flipping `layoutDirection` reverses *every* word box on the line, including consecutive Latin words that should stay in reading order among themselves:

For the input `...והיא עובדת מצוין עם Claude Code על מק`, the embedded Latin pair renders as **Code Claude** before this change and **Claude Code** after it.

Each line is now reordered with the Unicode Bidirectional Algorithm's L2 reordering rule applied at word granularity (`bidiVisualOrder`), so only the runs that need reversing are reversed. Each word is additionally wrapped in a directional isolate (RLI/LRI…PDI) so its own trailing punctuation and bracket mirroring resolve against the run it belongs to rather than against the ambient layout direction — otherwise `שלום,` puts the comma on the wrong side.

Numbers are treated as LTR, matching UBA rule I1 (European numbers always take an even embedding level), so `1.6.3` inside Hebrew text keeps its digits in order while still sitting at the correct point in the RTL flow.

### 3. The editor loses its direction on every keystroke

`HighlightingTextEditor.updateWritingDirection` sets the base writing direction, but `applyHighlighting` then calls `textStorage.setAttributes` over the full range with only `.font` and `.foregroundColor` — wiping the paragraph style that carries the direction. In `textDidChange` the two run in that exact order, so Hebrew snaps back to left-aligned as soon as you type. The paragraph style is now part of the default attribute set and of `typingAttributes`/`defaultParagraphStyle`, so it survives the reset.

### 4. The browser teleprompter treats every Hebrew word as a stage cue

`isAnnotation` and `letterCount` in the served HTML test against a hardcoded range list:

```js
/[a-zA-Z0-9À-ɏЀ-ӿ　-鿿가-힯]/
```

Hebrew, Arabic, Greek, Thai, Devanagari and others are absent, so every word in those scripts is classified as emoji-only: rendered dim and italic in the cue colour, skipped by the next-word scan, and never scrolled to. The browser view is completely non-functional for these languages. Both helpers now use `\p{L}`/`\p{N}`, which matches the native side's `isLetter || isNumber`, and the text container gets a `dir` attribute so the browser's own bidi engine orders each line.

### Base direction heuristic

`textBaseDirection` uses first-strong detection, which misreads a script opening with a Latin product name or speaker label — a single leading `Textream` lays an entire Hebrew page out left-to-right. Added `dominantBaseDirection`, which picks whichever script has more letters; scripts are read whole, so the dominant script is the better signal at page level. `textBaseDirection` is left in place.

Also added `dir="auto"` to the director page's script panes.

### Verification

Rendered `WordFlowLayout` directly through `ImageRenderer` across four fixtures — pure Hebrew, Hebrew with embedded English and numbers, Hebrew punctuation, and an English control. All three Hebrew cases are correct after the change; the English control is pixel-identical before and after. The browser-side classification and direction helpers were checked against Hebrew, Arabic, CJK, Greek, Latin, digit-only, emoji and bracketed-cue inputs.

Built and running locally on macOS 15 (Apple Silicon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
