### PR TITLE
docs: use official Homebrew install command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,7 +236,7 @@ jobs:
             Or install via Homebrew:
 
             ```
-            brew install f/textream/textream
+            brew install textream
             ```
 
       - name: Compute DMG SHA256

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Paste your script, hit play, and start speaking. When you're done, the overlay c
 Or install with Homebrew:
 
 ```bash
-brew install f/textream/textream
+brew install textream
 ```
 
 > Requires **macOS 15 Sequoia** or later. Works on Apple Silicon and Intel.

--- a/docs/index.html
+++ b/docs/index.html
@@ -3359,15 +3359,14 @@
     <div class="install-note">
       <h3>Install via Homebrew</h3>
       <p>You can also install Textream using Homebrew:</p>
-      <code>brew install f/textream/textream</code>
+      <code>brew install textream</code>
     </div>
 
     <!-- Install note -->
     <div class="install-note">
-      <h3>First Launch on macOS</h3>
-      <p>Textream is a free, independently distributed app. Since it isn't notarized through the Mac App Store, macOS may block it on first launch. To fix this, open Terminal and run:</p>
-      <code>xattr -cr /Applications/Textream.app</code>
-      <p style="margin-top: 12px;">Then right-click the app and choose <strong>Open</strong>. After the first launch, macOS remembers your choice and the app opens normally.</p>
+      <h3>Signed and notarized for macOS</h3>
+      <p>Textream is signed with a Developer ID certificate and notarized by Apple, so no Gatekeeper bypass is required. Install it, then open Textream normally.</p>
+      <p style="margin-top: 12px;">macOS may ask for Microphone and Speech Recognition access when you use the voice-guided modes.</p>
     </div>
 
     <!-- Footer -->


### PR DESCRIPTION
## Summary

- switch README and website installation instructions to `brew install textream`
- remove the obsolete Gatekeeper bypass from the website
- keep future release notes aligned with the official Homebrew cask

## Verification

- `brew install --dry-run textream`
- `git diff --check`
- served `docs/` locally and verified the page, GIF, and MP4 return HTTP 200