### PR TITLE
Prepare Textream for the Mac App Store

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 </p>
 
 <p align="center">
-  <a href="#download">Download</a> · <a href="#features">Features</a> · <a href="#how-it-works">How It Works</a> · <a href="#building-from-source">Build</a>
+  <a href="#download">Download</a> · <a href="#features">Features</a> · <a href="#how-it-works">How It Works</a> · <a href="#building-from-source">Build</a> · <a href="https://blog.fka.dev/textream/privacy.html">Privacy</a>
 </p>
 
 <p align="center">
@@ -46,7 +46,7 @@ brew install textream
 
 | Mode | Description | Microphone |
 |---|---|---|
-| **Word Tracking** (default) | On-device speech recognition highlights each word as you say it. No cloud, no latency, works offline. Supports dozens of languages. | Required |
+| **Word Tracking** (default) | macOS speech recognition highlights each word as you say it. Depending on your Mac, language, and system availability, recognition may happen on-device or Apple may process microphone audio. | Required |
 | **Classic** | Auto-scrolls at a constant speed. No microphone needed. | Not needed |
 | **Voice-Activated** | Scrolls while you speak, pauses when you're silent or muted. Perfect for natural pacing. | Required |
 
@@ -111,7 +111,7 @@ View your teleprompter on **any device** — phone, tablet, or another computer 
 - **Real-time sync** — Words highlight, waveform animates, and progress updates in real time over WebSocket.
 - **No app needed** — Works in any modern browser. No installation required on the remote device.
 - **Configurable port** — Default port 7373, adjustable in advanced settings.
-- **Fully local** — All traffic stays on your local network. Nothing leaves your Wi-Fi.
+- **Direct local connection** — Textream does not relay Remote Connection traffic through a developer server. Enable it only on a local network and with devices you trust.
 
 ### Director Mode
 
@@ -138,7 +138,7 @@ Let someone else control your teleprompter remotely. A director can write, edit,
 - **Tap to jump** — Tap any word in the overlay to jump the tracker to that position.
 - **Pause & resume** — Go off-script, take a break, come back. The tracker picks up where you left off.
 - **Mute / unmute** — Toggle the microphone on or off from the overlay in any mode.
-- **Completely private** — All processing happens on-device. No accounts, no tracking, no data leaves your Mac.
+- **Private by design** — No accounts, ads, analytics, or Textream-operated cloud service. Scripts and settings stay under your control. In Word Tracking mode, macOS speech recognition may send microphone audio to Apple for processing; see the [privacy policy](https://blog.fka.dev/textream/privacy.html).
 - **Auto update checker** — Checks GitHub Releases for new versions on launch and from the Textream menu.
 - **Open source** — MIT licensed. Contributions welcome.
 
@@ -185,7 +185,7 @@ Textream/
     ├── TextreamApp.swift              # App entry point, deep link handling
     ├── ContentView.swift              # Main text editor UI + About view
     ├── TextreamService.swift          # Service layer, URL scheme handling
-    ├── SpeechRecognizer.swift         # On-device speech recognition engine
+    ├── SpeechRecognizer.swift         # macOS speech recognition integration
     ├── NotchOverlayController.swift   # Dynamic Island + floating overlay
     ├── ExternalDisplayController.swift # Sidecar / external display output
     ├── NotchSettings.swift            # User preferences and presets
@@ -331,5 +331,6 @@ MIT
 
 <p align="center">
   Original idea by <a href="https://x.com/semihdev">Semih Kışlar</a> — thanks to him!<br>
-  Made by <a href="https://fka.dev">Fatih Kadir Akin</a>
+  Made by <a href="https://fka.dev">Fatih Kadir Akin</a><br>
+  <a href="https://blog.fka.dev/textream/privacy.html">Privacy</a> · <a href="https://blog.fka.dev/textream/support.html">Support</a>
 </p>

--- a/Textream/Textream.xcodeproj/project.pbxproj
+++ b/Textream/Textream.xcodeproj/project.pbxproj
@@ -247,6 +247,63 @@
 			};
 			name = Release;
 		};
+		446966C42F37E47400AF141F /* AppStore */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = RJA7656U34;
+				EMBED_ASSET_PACKS_IN_PRODUCT_BUNDLE = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+			};
+			name = AppStore;
+		};
 		446966C22F37E47400AF141F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -266,9 +323,10 @@
 				INFOPLIST_FILE = Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Textream;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
-				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2026 Fatih Kadir Akın";
+				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "Textream lets nearby devices view or control your teleprompter over your local network.";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Textream needs microphone access to listen to your speech and highlight words as you read them.";
-				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Textream uses speech recognition to follow along as you read and highlight the current word.";
+				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Textream uses Apple's speech-recognition service to follow along as you read and highlight the current word. Microphone audio may be processed by Apple.";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -305,9 +363,10 @@
 				INFOPLIST_FILE = Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Textream;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
-				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2026 Fatih Kadir Akın";
+				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "Textream lets nearby devices view or control your teleprompter over your local network.";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Textream needs microphone access to listen to your speech and highlight words as you read them.";
-				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Textream uses speech recognition to follow along as you read and highlight the current word.";
+				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Textream uses Apple's speech-recognition service to follow along as you read and highlight the current word. Microphone audio may be processed by Apple.";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -325,6 +384,47 @@
 			};
 			name = Release;
 		};
+		446966C52F37E47400AF141F /* AppStore */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
+				CODE_SIGN_ENTITLEMENTS = Textream/Textream.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = RJA7656U34;
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SELECTED_FILES = readwrite;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Textream;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2026 Fatih Kadir Akın";
+				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "Textream lets nearby devices view or control your teleprompter over your local network.";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Textream needs microphone access to listen to your speech and highlight words as you read them.";
+				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Textream uses Apple's speech-recognition service to follow along as you read and highlight the current word. Microphone audio may be processed by Apple.";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MARKETING_VERSION = 1.6.5;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.fka.textream;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "APP_STORE $(inherited)";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = AppStore;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -333,6 +433,7 @@
 			buildConfigurations = (
 				446966BF2F37E47400AF141F /* Debug */,
 				446966C02F37E47400AF141F /* Release */,
+				446966C42F37E47400AF141F /* AppStore */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -342,6 +443,7 @@
 			buildConfigurations = (
 				446966C22F37E47400AF141F /* Debug */,
 				446966C32F37E47400AF141F /* Release */,
+				446966C52F37E47400AF141F /* AppStore */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Textream/Textream/ContentView.swift
+++ b/Textream/Textream/ContentView.swift
@@ -852,6 +852,21 @@ struct AboutView: View {
                     .clipShape(Capsule())
                 }
 
+                Link(destination: URL(string: "https://blog.fka.dev/textream/privacy.html")!) {
+                    HStack(spacing: 5) {
+                        Image(systemName: "hand.raised.fill")
+                            .font(.system(size: 11, weight: .semibold))
+                        Text("Privacy")
+                            .font(.system(size: 12, weight: .medium))
+                    }
+                    .foregroundStyle(.primary)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 7)
+                    .background(Color.primary.opacity(0.08))
+                    .clipShape(Capsule())
+                }
+
+                #if !APP_STORE
                 Link(destination: URL(string: "https://donate.stripe.com/aFa8wO4NF2S96jDfn4dMI09")!) {
                     HStack(spacing: 5) {
                         Image(systemName: "heart.fill")
@@ -866,6 +881,7 @@ struct AboutView: View {
                     .background(Color.pink.opacity(0.1))
                     .clipShape(Capsule())
                 }
+                #endif
             }
 
             Divider().padding(.horizontal, 20)

--- a/Textream/Textream/Fonts/OpenDyslexic-OFL.txt
+++ b/Textream/Textream/Fonts/OpenDyslexic-OFL.txt
@@ -1,0 +1,94 @@
+Copyright (c) 2019-07-29, Abbie Gonzalez (https://abbiecod.es|support@abbiecod.es),
+with Reserved Font Name OpenDyslexic.
+Copyright (c) 12/2012 - 2019
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded, 
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/Textream/Textream/PrivacyInfo.xcprivacy
+++ b/Textream/Textream/PrivacyInfo.xcprivacy
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>35F9.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Textream/Textream/TextreamApp.swift
+++ b/Textream/Textream/TextreamApp.swift
@@ -35,8 +35,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             TextreamService.shared.hideMainWindow()
         }
 
-        // Silent update check on launch
+        #if !APP_STORE
+        // Direct-download builds check GitHub for updates. App Store builds are
+        // updated exclusively through the App Store.
         UpdateChecker.shared.checkForUpdates(silent: true)
+        #endif
 
         // Start browser server if enabled
         TextreamService.shared.updateBrowserServer()
@@ -135,10 +138,12 @@ struct TextreamApp: App {
                 Button("About Textream") {
                     NotificationCenter.default.post(name: .openAbout, object: nil)
                 }
+                #if !APP_STORE
                 Divider()
                 Button("Check for Updates…") {
                     UpdateChecker.shared.checkForUpdates()
                 }
+                #endif
             }
             CommandGroup(after: .appSettings) {
                 Button("Settings…") {

--- a/app-store/README.md
+++ b/app-store/README.md
@@ -1,0 +1,49 @@
+# Textream App Store submission drafts
+
+This directory contains working copy for an initial Mac App Store submission. Nothing here proves that an app record, build, page, screenshot, price, region, or submission is live.
+
+## Metadata
+
+The English (U.S.) draft is in `metadata/en-US/`:
+
+- `name.txt` — 8 characters; App Store limit 30.
+- `subtitle.txt` — 29 characters; App Store limit 30.
+- `description.txt` — long description; App Store limit 4,000 characters.
+- `keywords.txt` — 88 characters; App Store limit 100 bytes.
+- `promotional_text.txt` — 160 characters; App Store limit 170.
+- `support_url.txt`, `privacy_url.txt`, and `marketing_url.txt` — public web destinations.
+- `copyright.txt` — proposed rights-holder line.
+- `review_notes.txt` — draft testing instructions for App Review.
+
+The privacy and support URLs will be valid only after `docs/privacy.html` and `docs/support.html` are deployed to the canonical Textream site. Verify all three URLs in a signed-out browser before entering them in App Store Connect.
+
+## Build-dependent statements
+
+Before using this copy, verify the submitted archive itself:
+
+- App Store builds do not run or expose the GitHub update checker.
+- App Store builds do not expose an external donation or purchase link.
+- No analytics, advertising, tracking, crash-reporting, account, or developer backend was added.
+- Microphone, speech-recognition, and local-network purpose strings match actual behavior.
+- Remote and Director modes remain optional and local-network-only.
+- Review Notes steps work from a clean install with the permissions reset.
+
+If any point changes, update the description, review notes, privacy policy, and App Privacy answers together.
+
+## Account-holder decisions and attestations
+
+The account holder must review and personally confirm the following in App Store Connect:
+
+- final app name, subtitle, description, keywords, and SKU;
+- the exact copyright owner name and the right to publish all app content;
+- the App Privacy questionnaire in `app-privacy.md` against the uploaded binary;
+- export-compliance answers, including whether the build uses exempt encryption only;
+- age-rating questionnaire answers;
+- price, availability regions, and release method;
+- EU Digital Services Act trader status and any required public contact details;
+- App Review contact name, email address, and phone number;
+- all current developer agreements and tax or banking requirements;
+- the final screenshots and any accessibility or product claims;
+- the final **Submit for Review** action.
+
+Do not replace these attestations with assumptions from source code or an earlier build.

--- a/app-store/app-privacy.md
+++ b/app-store/app-privacy.md
@@ -1,0 +1,44 @@
+# App Privacy questionnaire draft
+
+This is a working draft for the App Store Connect questionnaire, not a completed legal attestation. The account holder must compare every answer with the exact binary being submitted and personally confirm it in App Store Connect.
+
+## Proposed top-level answers
+
+- **Does this app collect data from this app?** No.
+- **Is any data used to track users?** No.
+- **Privacy Policy URL:** https://blog.fka.dev/textream/privacy.html
+
+These proposed answers are based on the following build assumptions:
+
+- the App Store build has no analytics, advertising, crash-reporting, attribution, or tracking SDK;
+- the App Store build does not use the direct-download GitHub update checker;
+- the developer does not operate an account, synchronization, speech, storage, or telemetry service for Textream;
+- scripts, imported presentation notes, and preferences are processed locally unless the user explicitly enables a local-network feature;
+- Remote Connection and Director Mode communicate directly with devices the user connects on the same local network; the developer does not receive that traffic;
+- Apple’s Speech framework may process microphone audio on-device or through Apple, but Textream’s developer does not receive the audio or recognition result;
+- no later code, embedded framework, or SDK changes the statements above.
+
+## Why microphone and speech do not automatically mean “data collected”
+
+App Store privacy answers describe data collected by the developer or third parties integrated into the app. Permission to use microphone audio is still privacy-sensitive and must be disclosed clearly, but Apple-framework processing that the developer cannot access is not represented here as developer collection. Re-check Apple’s current App Privacy guidance when submitting.
+
+## Permissions and user-facing disclosures to verify
+
+- Microphone purpose text explains that voice-guided modes need audio input.
+- Speech Recognition purpose text explains that microphone audio may be sent to Apple for recognition.
+- Local Network purpose text explains Remote Connection and Director Mode.
+- The in-app About screen links to the published privacy policy.
+- The public privacy policy matches the behavior of the uploaded build.
+
+## Local-network privacy note
+
+Remote Connection can expose script text and reading state to a connected device. Director Mode can also accept script edits and control commands. These features are user-enabled and local, but their HTTP and WebSocket traffic is not end-to-end encrypted. The public privacy policy tells users to use a trusted network and disable the features afterward.
+
+## Re-check immediately before attesting
+
+1. Inspect the archived app for embedded SDKs and frameworks.
+2. Exercise every feature while monitoring outbound connections.
+3. Confirm the App Store build has no direct-update request, donation flow, account flow, analytics, or developer backend.
+4. Confirm the final privacy-policy page is publicly reachable without login.
+5. Re-read Apple’s current definitions of “collect” and “tracking.”
+6. Have the account holder submit the answers personally.

--- a/app-store/metadata/en-US/copyright.txt
+++ b/app-store/metadata/en-US/copyright.txt
@@ -1,0 +1,1 @@
+2026 Fatih Kadir Akin

--- a/app-store/metadata/en-US/description.txt
+++ b/app-store/metadata/en-US/description.txt
@@ -1,0 +1,30 @@
+Keep your eyes on the camera and your place in the script.
+
+Textream is a flexible teleprompter for presentations, streams, interviews, podcasts, and recorded videos. Paste a script, choose how you want to be guided, and place the teleprompter where it works best for you.
+
+THREE WAYS TO STAY ON SCRIPT
+
+• Word Tracking follows along as you speak using macOS speech recognition.
+• Classic mode scrolls at a steady, adjustable pace without using the microphone.
+• Voice-Activated mode scrolls while you speak and pauses when you stop.
+
+PUT THE SCRIPT WHERE YOU NEED IT
+
+• Pin a compact teleprompter below your MacBook notch.
+• Use a draggable, always-on-top floating window.
+• Read fullscreen on your Mac, an external display, or a Sidecar iPad.
+• Mirror the external-display output for a teleprompter rig.
+
+MAKE IT YOURS
+
+Choose from multiple typefaces, text sizes, highlight colors, overlay sizes, and glass effects. OpenDyslexic is included as a reading option. Save multi-page scripts as .textream files, or import presenter notes from a PowerPoint file.
+
+OPTIONAL LOCAL-NETWORK TOOLS
+
+Remote Connection displays your teleprompter on another device through a local-network browser. Director Mode lets a trusted person on that network edit and control the script from their browser. No companion app is required.
+
+PRIVATE BY DESIGN
+
+Textream has no account, ads, analytics, or developer-operated cloud service. Scripts and settings remain under your control. Word Tracking uses Apple’s speech-recognition framework; depending on your Mac, language, and system availability, macOS may process speech on-device or send microphone audio to Apple.
+
+No account required.

--- a/app-store/metadata/en-US/keywords.txt
+++ b/app-store/metadata/en-US/keywords.txt
@@ -1,0 +1,1 @@
+teleprompter,presenter,script,speech,streaming,podcast,notch,autoscroll,sidecar,prompter

--- a/app-store/metadata/en-US/marketing_url.txt
+++ b/app-store/metadata/en-US/marketing_url.txt
@@ -1,0 +1,1 @@
+https://blog.fka.dev/textream/

--- a/app-store/metadata/en-US/name.txt
+++ b/app-store/metadata/en-US/name.txt
@@ -1,0 +1,1 @@
+Textream

--- a/app-store/metadata/en-US/privacy_url.txt
+++ b/app-store/metadata/en-US/privacy_url.txt
@@ -1,0 +1,1 @@
+https://blog.fka.dev/textream/privacy.html

--- a/app-store/metadata/en-US/promotional_text.txt
+++ b/app-store/metadata/en-US/promotional_text.txt
@@ -1,0 +1,1 @@
+Keep your place without looking away. Textream follows your voice, scrolls at your pace, and puts your script in a pinned, floating, or fullscreen teleprompter.

--- a/app-store/metadata/en-US/review_notes.txt
+++ b/app-store/metadata/en-US/review_notes.txt
@@ -1,0 +1,14 @@
+Textream requires no account, purchase, demo credentials, or external hardware.
+
+To test the core experience:
+1. Launch Textream and keep the sample script, or paste any text into the editor.
+2. Click the Play button in the lower-left corner.
+3. Grant Microphone and Speech Recognition access when macOS asks.
+4. Read the script aloud. Word Tracking highlights the current words in the teleprompter overlay.
+5. Stop the session from the overlay or the main Textream window.
+
+The app can also be tested without microphone access: open Textream Settings → Guidance, choose Classic, return to the editor, and click Play. Classic mode scrolls at a fixed speed.
+
+Remote Connection and Director Mode are optional local-network features. To test either feature, enable it in the corresponding Settings tab, then open the address displayed by Textream on a second device on the same network. No remote Textream service is involved.
+
+PowerPoint import expects a .pptx document containing presenter notes. No sample document or external service is required for the rest of the app.

--- a/app-store/metadata/en-US/subtitle.txt
+++ b/app-store/metadata/en-US/subtitle.txt
@@ -1,0 +1,1 @@
+Teleprompter That Follows You

--- a/app-store/metadata/en-US/support_url.txt
+++ b/app-store/metadata/en-US/support_url.txt
@@ -1,0 +1,1 @@
+https://blog.fka.dev/textream/support.html

--- a/docs/index.html
+++ b/docs/index.html
@@ -2990,11 +2990,11 @@
     <!-- Features -->
     <section class="features">
       <h2>How it keeps you on track</h2>
-      <p class="section-sub">Powered by macOS speech recognition. No cloud. No latency.</p>
+      <p class="section-sub">Powered by macOS speech recognition. No account required.</p>
       <div class="features-list">
         <div class="feat-item">
           <div class="feat-dot"><svg viewBox="0 0 24 24"><path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/></svg></div>
-          <div class="feat-text"><h3>Real-Time Voice Tracking</h3><p>Highlights each word as you say it using on-device speech recognition. Fast, private, offline. Supports dozens of languages.</p></div>
+          <div class="feat-text"><h3>Real-Time Voice Tracking</h3><p>Highlights each word as you say it using macOS speech recognition. Processing depends on your Mac, selected language, and system availability.</p></div>
         </div>
         <div class="feat-item">
           <div class="feat-dot"><svg viewBox="0 0 24 24"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"/></svg></div>
@@ -3054,7 +3054,7 @@
         </div>
         <div class="feat-item">
           <div class="feat-dot"><svg viewBox="0 0 24 24"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg></div>
-          <div class="feat-text"><h3>Completely Private</h3><p>All recognition on-device. No data leaves your Mac. No accounts, no tracking, no cloud.</p></div>
+          <div class="feat-text"><h3>Private by Design</h3><p>No account, ads, analytics, or Textream-operated cloud service. macOS may send microphone audio to Apple for speech processing.</p></div>
         </div>
         <div class="feat-item">
           <div class="feat-dot"><svg viewBox="0 0 24 24"><path d="M21 2H3v16h18V2z"/><path d="M12 18v4"/><path d="M8 22h8"/></svg></div>
@@ -3372,7 +3372,7 @@
     <!-- Footer -->
     <footer>
       <p>Original idea by <a href="https://x.com/semihdev">Semih Kışlar</a> &mdash; thanks to him!</p>
-      <p>Made by <a href="https://fka.dev">Fatih Kadir Akin</a> &middot; <a href="https://github.com/f/textream">Source on GitHub</a></p>
+      <p>Made by <a href="https://fka.dev">Fatih Kadir Akin</a> &middot; <a href="https://github.com/f/textream">Source on GitHub</a> &middot; <a href="privacy.html">Privacy</a> &middot; <a href="support.html">Support</a></p>
     </footer>
   </div>
 </body>

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -1,0 +1,299 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="color-scheme" content="dark">
+  <title>Privacy Policy — Textream</title>
+  <meta name="description" content="How Textream handles scripts, microphone audio, speech recognition, local-network features, and app settings.">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; }
+
+    :root {
+      --bg: #0a0a0c;
+      --surface: #1c1c1e;
+      --surface2: #242428;
+      --text: #f5f5f7;
+      --muted: #a1a1a8;
+      --quiet: #6e6e76;
+      --line: rgba(255, 255, 255, 0.08);
+      --accent1: #7c6aff;
+      --accent2: #4f8bff;
+    }
+
+    html { scroll-behavior: smooth; }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Helvetica Neue", sans-serif;
+      color: var(--text);
+      background:
+        radial-gradient(circle at 50% -15%, rgba(124, 106, 255, 0.15), transparent 42rem),
+        var(--bg);
+      line-height: 1.65;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    a { color: #8eb4ff; }
+    a:hover { color: #b9ceff; }
+
+    .shell {
+      width: min(100% - 40px, 880px);
+      margin: 0 auto;
+    }
+
+    nav {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 22px 0;
+      border-bottom: 1px solid var(--line);
+    }
+
+    .brand {
+      display: inline-flex;
+      align-items: center;
+      gap: 11px;
+      color: var(--text);
+      font-weight: 750;
+      letter-spacing: -0.02em;
+      text-decoration: none;
+    }
+
+    .brand-mark {
+      display: grid;
+      place-items: center;
+      width: 34px;
+      height: 34px;
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      border-radius: 10px;
+      background: linear-gradient(145deg, #29292d, #111114);
+      box-shadow: 0 8px 28px rgba(0, 0, 0, 0.35);
+    }
+
+    .brand-mark span {
+      font-size: 21px;
+      font-weight: 850;
+      line-height: 1;
+      background: linear-gradient(135deg, var(--accent1), var(--accent2));
+      background-clip: text;
+      -webkit-background-clip: text;
+      color: transparent;
+    }
+
+    .nav-links { display: flex; gap: 18px; }
+    .nav-links a { color: var(--muted); font-size: 14px; text-decoration: none; }
+    .nav-links a:hover { color: var(--text); }
+
+    header { padding: 92px 0 56px; }
+
+    .eyebrow {
+      margin: 0 0 14px;
+      color: #9dbbff;
+      font-size: 13px;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    h1 {
+      max-width: 700px;
+      margin: 0 0 22px;
+      font-size: clamp(42px, 8vw, 72px);
+      line-height: 1.02;
+      letter-spacing: -0.05em;
+    }
+
+    .lede {
+      max-width: 700px;
+      margin: 0;
+      color: var(--muted);
+      font-size: clamp(18px, 3vw, 22px);
+      line-height: 1.55;
+    }
+
+    .summary {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 12px;
+      margin: 10px 0 72px;
+    }
+
+    .summary article {
+      min-height: 148px;
+      padding: 22px;
+      border: 1px solid var(--line);
+      border-radius: 18px;
+      background: linear-gradient(155deg, rgba(42, 42, 47, 0.94), rgba(23, 23, 26, 0.94));
+    }
+
+    .summary strong { display: block; margin-bottom: 8px; font-size: 15px; }
+    .summary p { margin: 0; color: var(--muted); font-size: 14px; line-height: 1.55; }
+
+    main { padding-bottom: 84px; }
+
+    section {
+      display: grid;
+      grid-template-columns: 190px minmax(0, 1fr);
+      gap: 42px;
+      padding: 34px 0;
+      border-top: 1px solid var(--line);
+    }
+
+    h2 {
+      margin: 2px 0 0;
+      font-size: 17px;
+      line-height: 1.35;
+      letter-spacing: -0.015em;
+    }
+
+    .copy p { margin: 0 0 16px; color: #c8c8ce; }
+    .copy p:last-child { margin-bottom: 0; }
+    .copy ul { margin: 0; padding-left: 20px; color: #c8c8ce; }
+    .copy li + li { margin-top: 9px; }
+    .copy strong { color: var(--text); }
+
+    .note {
+      padding: 18px 20px;
+      border: 1px solid rgba(124, 106, 255, 0.22);
+      border-radius: 14px;
+      background: rgba(124, 106, 255, 0.07);
+      color: #d8d4ff;
+    }
+
+    footer {
+      display: flex;
+      justify-content: space-between;
+      gap: 24px;
+      padding: 30px 0 42px;
+      border-top: 1px solid var(--line);
+      color: var(--quiet);
+      font-size: 13px;
+    }
+
+    footer p { margin: 0; }
+    footer a { color: var(--muted); text-decoration: none; }
+
+    @media (max-width: 700px) {
+      .summary { grid-template-columns: 1fr; }
+      .summary article { min-height: 0; }
+      section { grid-template-columns: 1fr; gap: 14px; }
+      header { padding-top: 64px; }
+      .nav-links a:first-child { display: none; }
+      footer { flex-direction: column; }
+    }
+  </style>
+</head>
+<body>
+  <div class="shell">
+    <nav aria-label="Primary navigation">
+      <a class="brand" href="./" aria-label="Textream home">
+        <span class="brand-mark" aria-hidden="true"><span>T</span></span>
+        Textream
+      </a>
+      <div class="nav-links">
+        <a href="https://github.com/f/textream">GitHub</a>
+        <a href="support.html">Support</a>
+      </div>
+    </nav>
+
+    <header>
+      <p class="eyebrow">Privacy policy · Updated August 10, 2026</p>
+      <h1>Privacy, without fine print.</h1>
+      <p class="lede">Textream does not require an account and its developer does not operate a service that receives your scripts. A few macOS and optional network features deserve a clear explanation.</p>
+    </header>
+
+    <div class="summary" aria-label="Privacy summary">
+      <article>
+        <strong>Your scripts are yours</strong>
+        <p>Textream keeps working text and preferences on your Mac. You choose where saved script files live.</p>
+      </article>
+      <article>
+        <strong>No ads or analytics</strong>
+        <p>The app has no advertising, behavioral tracking, analytics SDK, or Textream account.</p>
+      </article>
+      <article>
+        <strong>You control the microphone</strong>
+        <p>Voice-guided modes run only after you grant permission. You can revoke access in macOS Settings.</p>
+      </article>
+    </div>
+
+    <main>
+      <section>
+        <h2>Information Textream collects</h2>
+        <div class="copy">
+          <p>The Textream developer does not collect personal data through the app. Textream has no developer-operated account system, analytics service, advertising system, or cloud storage service.</p>
+          <p>This describes collection by Textream and its developer. Apple, GitHub, your network provider, or another service you choose to use may process connection or device information under their own policies.</p>
+        </div>
+      </section>
+
+      <section>
+        <h2>Microphone and speech recognition</h2>
+        <div class="copy">
+          <p>Word Tracking and Voice-Activated modes use microphone access when you start them. Word Tracking uses Apple’s speech-recognition framework to match spoken words to your script.</p>
+          <p><strong>Speech recognition is not guaranteed to stay on-device.</strong> Depending on your Mac, language, macOS version, and service availability, macOS may process speech locally or send microphone audio to Apple for recognition. Textream’s developer does not receive that audio or the recognition result.</p>
+          <p>You can use Classic mode without microphone or speech-recognition access. You can also change permissions at any time in System Settings → Privacy &amp; Security.</p>
+          <p>Apple describes its handling of data in the <a href="https://www.apple.com/legal/privacy/">Apple Privacy Policy</a>.</p>
+        </div>
+      </section>
+
+      <section>
+        <h2>Scripts, files, and settings</h2>
+        <div class="copy">
+          <p>Textream stores editor content and preferences locally on your Mac. When you save a <code>.textream</code> file, import PowerPoint notes, or open another document, the file is handled locally and remains in a location you control.</p>
+          <p>Textream does not upload those files to a Textream server. You can remove saved scripts using Finder. Removing the app does not necessarily remove preferences that macOS keeps for it.</p>
+        </div>
+      </section>
+
+      <section>
+        <h2>Remote and Director modes</h2>
+        <div class="copy">
+          <p>Remote Connection and Director Mode are off until you enable them. When enabled, Textream starts a server on your Mac so another device on the local network can view teleprompter state or control the script.</p>
+          <ul>
+            <li>Connected devices may receive script text, reading position, and display state.</li>
+            <li>Director Mode lets a connected device send or edit script text.</li>
+            <li>These features use local HTTP and WebSocket connections that are not end-to-end encrypted.</li>
+          </ul>
+          <p class="note">Use these modes only on a network and with devices you trust. Turn them off when you are finished, and do not share the connection address or QR code publicly.</p>
+        </div>
+      </section>
+
+      <section>
+        <h2>Other network connections</h2>
+        <div class="copy">
+          <p>In a Mac App Store build, updates are delivered by Apple. A version installed directly from GitHub or Homebrew may contact GitHub to check whether a newer release exists. GitHub may receive standard connection information such as an IP address; see the <a href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement">GitHub Privacy Statement</a>.</p>
+          <p>If you follow a link from Textream to a website, that site handles the resulting connection under its own policy.</p>
+        </div>
+      </section>
+
+      <section>
+        <h2>Screen sharing</h2>
+        <div class="copy">
+          <p>The “Hide from Screen Sharing” setting asks macOS to exclude Textream’s teleprompter overlay from screen captures. It does not control other apps, cameras, external capture hardware, or content outside Textream. Confirm your recording or meeting setup before relying on it.</p>
+        </div>
+      </section>
+
+      <section>
+        <h2>Retention and deletion</h2>
+        <div class="copy">
+          <p>Because the developer does not receive your scripts or maintain a Textream account, there is no Textream server copy to retain or delete. You control saved scripts on your Mac and can delete them whenever you choose.</p>
+        </div>
+      </section>
+
+      <section>
+        <h2>Changes and contact</h2>
+        <div class="copy">
+          <p>If Textream’s data practices change, this page will be updated along with its effective date.</p>
+          <p>For a privacy question or support request, visit <a href="support.html">Textream Support</a> or <a href="https://github.com/f/textream/issues/new">open a GitHub issue</a>. Do not include private scripts, credentials, or other sensitive information in a public issue.</p>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <p>© 2026 Fatih Kadir Akin</p>
+      <p><a href="./">Textream</a> · <a href="support.html">Support</a> · <a href="https://github.com/f/textream">Source</a></p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/docs/support.html
+++ b/docs/support.html
@@ -1,0 +1,325 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="color-scheme" content="dark">
+  <title>Support — Textream</title>
+  <meta name="description" content="Setup help, troubleshooting, and support for the Textream teleprompter app for macOS.">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; }
+
+    :root {
+      --bg: #0a0a0c;
+      --surface: #1c1c1e;
+      --surface2: #28282c;
+      --text: #f5f5f7;
+      --muted: #a1a1a8;
+      --quiet: #6e6e76;
+      --line: rgba(255, 255, 255, 0.08);
+      --accent1: #7c6aff;
+      --accent2: #4f8bff;
+    }
+
+    html { scroll-behavior: smooth; }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Helvetica Neue", sans-serif;
+      color: var(--text);
+      background:
+        radial-gradient(circle at 50% -15%, rgba(79, 139, 255, 0.15), transparent 42rem),
+        var(--bg);
+      line-height: 1.65;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    a { color: #8eb4ff; }
+    a:hover { color: #b9ceff; }
+
+    .shell {
+      width: min(100% - 40px, 920px);
+      margin: 0 auto;
+    }
+
+    nav {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 22px 0;
+      border-bottom: 1px solid var(--line);
+    }
+
+    .brand {
+      display: inline-flex;
+      align-items: center;
+      gap: 11px;
+      color: var(--text);
+      font-weight: 750;
+      letter-spacing: -0.02em;
+      text-decoration: none;
+    }
+
+    .brand-mark {
+      display: grid;
+      place-items: center;
+      width: 34px;
+      height: 34px;
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      border-radius: 10px;
+      background: linear-gradient(145deg, #29292d, #111114);
+      box-shadow: 0 8px 28px rgba(0, 0, 0, 0.35);
+    }
+
+    .brand-mark span {
+      font-size: 21px;
+      font-weight: 850;
+      line-height: 1;
+      background: linear-gradient(135deg, var(--accent1), var(--accent2));
+      background-clip: text;
+      -webkit-background-clip: text;
+      color: transparent;
+    }
+
+    .nav-links { display: flex; gap: 18px; }
+    .nav-links a { color: var(--muted); font-size: 14px; text-decoration: none; }
+    .nav-links a:hover { color: var(--text); }
+
+    header { padding: 92px 0 54px; }
+
+    .eyebrow {
+      margin: 0 0 14px;
+      color: #9dbbff;
+      font-size: 13px;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    h1 {
+      max-width: 720px;
+      margin: 0 0 22px;
+      font-size: clamp(42px, 8vw, 72px);
+      line-height: 1.02;
+      letter-spacing: -0.05em;
+    }
+
+    .lede {
+      max-width: 660px;
+      margin: 0;
+      color: var(--muted);
+      font-size: clamp(18px, 3vw, 22px);
+      line-height: 1.55;
+    }
+
+    .primary-action {
+      display: inline-flex;
+      align-items: center;
+      gap: 9px;
+      margin-top: 30px;
+      padding: 13px 20px;
+      border-radius: 12px;
+      background: linear-gradient(135deg, var(--accent1), var(--accent2));
+      box-shadow: 0 12px 36px rgba(79, 139, 255, 0.22);
+      color: white;
+      font-size: 15px;
+      font-weight: 700;
+      text-decoration: none;
+      transition: transform 160ms ease, box-shadow 160ms ease;
+    }
+
+    .primary-action:hover {
+      color: white;
+      transform: translateY(-2px);
+      box-shadow: 0 16px 44px rgba(79, 139, 255, 0.3);
+    }
+
+    .before-posting {
+      margin: 18px 0 68px;
+      padding: 24px 26px;
+      border: 1px solid rgba(124, 106, 255, 0.22);
+      border-radius: 18px;
+      background: rgba(124, 106, 255, 0.07);
+    }
+
+    .before-posting h2 { margin: 0 0 11px; font-size: 17px; }
+    .before-posting p { margin: 0; color: #cbc8eb; }
+
+    .troubleshooting { padding-bottom: 78px; }
+    .troubleshooting > h2 { margin: 0 0 24px; font-size: 28px; letter-spacing: -0.025em; }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 14px;
+    }
+
+    .card {
+      padding: 25px;
+      border: 1px solid var(--line);
+      border-radius: 18px;
+      background: linear-gradient(155deg, rgba(42, 42, 47, 0.94), rgba(23, 23, 26, 0.94));
+    }
+
+    .card .number {
+      display: grid;
+      place-items: center;
+      width: 30px;
+      height: 30px;
+      margin-bottom: 18px;
+      border-radius: 9px;
+      background: rgba(79, 139, 255, 0.12);
+      color: #9dbbff;
+      font-size: 13px;
+      font-weight: 800;
+    }
+
+    .card h3 { margin: 0 0 9px; font-size: 17px; letter-spacing: -0.015em; }
+    .card p { margin: 0; color: var(--muted); font-size: 14px; }
+    .card p + p { margin-top: 12px; }
+
+    .details {
+      display: grid;
+      grid-template-columns: 190px minmax(0, 1fr);
+      gap: 42px;
+      padding: 34px 0;
+      border-top: 1px solid var(--line);
+    }
+
+    .details h2 { margin: 2px 0 0; font-size: 17px; line-height: 1.35; }
+    .details p { margin: 0 0 14px; color: #c8c8ce; }
+    .details ul { margin: 0; padding-left: 20px; color: #c8c8ce; }
+    .details li + li { margin-top: 8px; }
+
+    code {
+      padding: 2px 6px;
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      background: var(--surface);
+      color: #d5d5db;
+      font-family: "SFMono-Regular", Consolas, monospace;
+      font-size: 0.88em;
+    }
+
+    footer {
+      display: flex;
+      justify-content: space-between;
+      gap: 24px;
+      padding: 30px 0 42px;
+      border-top: 1px solid var(--line);
+      color: var(--quiet);
+      font-size: 13px;
+    }
+
+    footer p { margin: 0; }
+    footer a { color: var(--muted); text-decoration: none; }
+
+    @media (max-width: 700px) {
+      header { padding-top: 64px; }
+      .grid { grid-template-columns: 1fr; }
+      .details { grid-template-columns: 1fr; gap: 14px; }
+      .nav-links a:first-child { display: none; }
+      footer { flex-direction: column; }
+    }
+  </style>
+</head>
+<body>
+  <div class="shell">
+    <nav aria-label="Primary navigation">
+      <a class="brand" href="./" aria-label="Textream home">
+        <span class="brand-mark" aria-hidden="true"><span>T</span></span>
+        Textream
+      </a>
+      <div class="nav-links">
+        <a href="https://github.com/f/textream">GitHub</a>
+        <a href="privacy.html">Privacy</a>
+      </div>
+    </nav>
+
+    <header>
+      <p class="eyebrow">Textream support</p>
+      <h1>Let’s get you back on script.</h1>
+      <p class="lede">Find quick fixes for permissions, overlays, local-network connections, and document imports. If the problem persists, report it in the open-source project.</p>
+      <a class="primary-action" href="https://github.com/f/textream/issues/new">Open a support issue <span aria-hidden="true">↗</span></a>
+    </header>
+
+    <aside class="before-posting">
+      <h2>Before posting publicly</h2>
+      <p>Remove private scripts, credentials, QR codes, local IP addresses, and personal details from screenshots or logs. Textream support does not need your script to diagnose most problems.</p>
+    </aside>
+
+    <main>
+      <section class="troubleshooting">
+        <h2>Quick fixes</h2>
+        <div class="grid">
+          <article class="card">
+            <span class="number">01</span>
+            <h3>Word tracking does not start</h3>
+            <p>Open System Settings → Privacy &amp; Security and allow Textream under both Microphone and Speech Recognition. Quit and reopen Textream after changing permissions.</p>
+          </article>
+          <article class="card">
+            <span class="number">02</span>
+            <h3>The overlay is on the wrong screen</h3>
+            <p>Open Textream Settings → Teleprompter. Choose Follow Mouse to move between displays, or Fixed Display to keep the overlay on one screen.</p>
+          </article>
+          <article class="card">
+            <span class="number">03</span>
+            <h3>Remote or Director Mode will not connect</h3>
+            <p>Put both devices on the same trusted network, enable the mode in Settings, and open the address shown by Textream. If prompted, allow incoming connections in the macOS firewall.</p>
+          </article>
+          <article class="card">
+            <span class="number">04</span>
+            <h3>PowerPoint notes do not import</h3>
+            <p>Use a <code>.pptx</code> file that contains presenter notes. For Keynote or Google Slides, export to PowerPoint first, then import the exported file.</p>
+          </article>
+          <article class="card">
+            <span class="number">05</span>
+            <h3>The overlay appears in a recording</h3>
+            <p>Turn on Hide from Screen Sharing in Teleprompter settings before recording. Then make a short test recording: capture apps and external hardware do not all behave the same way.</p>
+          </article>
+          <article class="card">
+            <span class="number">06</span>
+            <h3>Textream will not update</h3>
+            <p>For a Mac App Store installation, update it there. If installed with Homebrew, run <code>brew upgrade textream</code>. Direct downloads are published on GitHub Releases.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="details">
+        <h2>What to include</h2>
+        <div>
+          <p>A useful report includes:</p>
+          <ul>
+            <li>your macOS and Textream versions;</li>
+            <li>your Mac model and whether it uses Apple silicon or Intel;</li>
+            <li>the guidance and overlay modes you selected;</li>
+            <li>steps that reproduce the problem;</li>
+            <li>what you expected and what happened instead.</li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="details">
+        <h2>Where to ask</h2>
+        <div>
+          <p>Search <a href="https://github.com/f/textream/issues">existing GitHub issues</a> first. If you do not find a match, <a href="https://github.com/f/textream/issues/new">open a new issue</a>.</p>
+          <p>Textream is a free, open-source project. Support is provided on a best-effort basis; there is no guaranteed response time.</p>
+        </div>
+      </section>
+
+      <section class="details">
+        <h2>Privacy</h2>
+        <div>
+          <p>Read the <a href="privacy.html">Textream Privacy Policy</a> for details about microphone access, Apple speech recognition, saved scripts, and optional local-network features.</p>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <p>© 2026 Fatih Kadir Akin</p>
+      <p><a href="./">Textream</a> · <a href="privacy.html">Privacy</a> · <a href="https://github.com/f/textream">Source</a></p>
+    </footer>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- add a dedicated `AppStore` build configuration with automatic Apple signing, App Sandbox, hardened runtime, and the required entitlements
- disable the GitHub updater and external donation link only in App Store builds
- add the privacy manifest and accurate microphone, speech-recognition, and local-network disclosures
- publish App Store metadata drafts plus public privacy and support pages
- include the SIL Open Font License for the bundled OpenDyslexic font

## Verification

- `git diff --check`
- App Store configuration builds and analyzes successfully
- Release configuration still builds and retains the updater/donation behavior
- App Store binary contains the privacy manifest and omits updater/Stripe strings
- metadata fields fit their App Store limits

The generated App Store screenshots are kept separately from this source change and will be uploaded directly to App Store Connect.

Prepared with Codex assistance; reviewed and submitted by Fatih.