### PR TITLE
Declare App Store export compliance

### DIFF
--- a/Textream/Textream.xcodeproj/project.pbxproj
+++ b/Textream/Textream.xcodeproj/project.pbxproj
@@ -402,6 +402,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Textream;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2026 Fatih Kadir Akın";
 				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "Textream lets nearby devices view or control your teleprompter over your local network.";


### PR DESCRIPTION
## Summary

Declare `ITSAppUsesNonExemptEncryption = NO` only for the Mac App Store configuration. Textream does not implement encryption algorithms; its App Store build relies only on Apple-provided system facilities.

## Verification

- App Store configuration builds for `arm64` and `x86_64`
- generated App Store `Info.plist` contains the Boolean value `false`
- direct-download Release behavior is unchanged
- `git diff --check`

Prepared with Codex assistance; reviewed and submitted by Fatih.