### PR TITLE
Add direct support email

### DIFF
--- a/docs/support.html
+++ b/docs/support.html
@@ -304,6 +304,7 @@
         <h2>Where to ask</h2>
         <div>
           <p>Search <a href="https://github.com/f/textream/issues">existing GitHub issues</a> first. If you do not find a match, <a href="https://github.com/f/textream/issues/new">open a new issue</a>.</p>
+          <p>For direct support, email <a href="mailto:fka@linux.com">fka@linux.com</a>.</p>
           <p>Textream is a free, open-source project. Support is provided on a best-effort basis; there is no guaranteed response time.</p>
         </div>
       </section>

--- a/docs/support.html
+++ b/docs/support.html
@@ -304,7 +304,7 @@
         <h2>Where to ask</h2>
         <div>
           <p>Search <a href="https://github.com/f/textream/issues">existing GitHub issues</a> first. If you do not find a match, <a href="https://github.com/f/textream/issues/new">open a new issue</a>.</p>
-          <p>For direct support, email <a href="mailto:fka@linux.com">fka@linux.com</a>.</p>
+          <p>For direct support, email <a href="mailto:fka@linux.com">fka@linux.com</a>. The same privacy guidance above applies to anything you send by email.</p>
           <p>Textream is a free, open-source project. Support is provided on a best-effort basis; there is no guaranteed response time.</p>
         </div>
       </section>


### PR DESCRIPTION
Adds the public support email to the support page alongside GitHub Issues while retaining the privacy warning.

Validation: `tidy -errors -quiet docs/support.html`

Prepared with Codex assistance.