### PR TITLE
docs: remove signed and notarized note

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3362,13 +3362,6 @@
       <code>brew install textream</code>
     </div>
 
-    <!-- Install note -->
-    <div class="install-note">
-      <h3>Signed and notarized for macOS</h3>
-      <p>Textream is signed with a Developer ID certificate and notarized by Apple, so no Gatekeeper bypass is required. Install it, then open Textream normally.</p>
-      <p style="margin-top: 12px;">macOS may ask for Microphone and Speech Recognition access when you use the voice-guided modes.</p>
-    </div>
-
     <!-- Footer -->
     <footer>
       <p>Original idea by <a href="https://x.com/semihdev">Semih Kışlar</a> &mdash; thanks to him!</p>


### PR DESCRIPTION
## Summary
- remove the signed and notarized installation note from the website
- keep the official `brew install textream` command unchanged

## Checks
- `git diff --check`
- verified the removed heading is absent from `docs/index.html`

Prepared with Codex assistance.