### PR TITLE
Configure textream.net as the canonical domain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,7 +271,7 @@ jobs:
 
             name "Textream"
             desc "Teleprompter that highlights scripts in real time as you speak"
-            homepage "https://github.com/f/textream"
+            homepage "https://textream.net/"
 
             depends_on macos: :sequoia
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 </p>
 
 <p align="center">
-  <a href="#download">Download</a> · <a href="#features">Features</a> · <a href="#how-it-works">How It Works</a> · <a href="#building-from-source">Build</a> · <a href="https://blog.fka.dev/textream/privacy.html">Privacy</a>
+  <a href="#download">Download</a> · <a href="#features">Features</a> · <a href="#how-it-works">How It Works</a> · <a href="#building-from-source">Build</a> · <a href="https://textream.net/privacy.html">Privacy</a>
 </p>
 
 <p align="center">
@@ -138,7 +138,7 @@ Let someone else control your teleprompter remotely. A director can write, edit,
 - **Tap to jump** — Tap any word in the overlay to jump the tracker to that position.
 - **Pause & resume** — Go off-script, take a break, come back. The tracker picks up where you left off.
 - **Mute / unmute** — Toggle the microphone on or off from the overlay in any mode.
-- **Private by design** — No accounts, ads, analytics, or Textream-operated cloud service. Scripts and settings stay under your control. In Word Tracking mode, macOS speech recognition may send microphone audio to Apple for processing; see the [privacy policy](https://blog.fka.dev/textream/privacy.html).
+- **Private by design** — No accounts, ads, analytics, or Textream-operated cloud service. Scripts and settings stay under your control. In Word Tracking mode, macOS speech recognition may send microphone audio to Apple for processing; see the [privacy policy](https://textream.net/privacy.html).
 - **Auto update checker** — Checks GitHub Releases for new versions on launch and from the Textream menu.
 - **Open source** — MIT licensed. Contributions welcome.
 
@@ -332,5 +332,5 @@ MIT
 <p align="center">
   Original idea by <a href="https://x.com/semihdev">Semih Kışlar</a> — thanks to him!<br>
   Made by <a href="https://fka.dev">Fatih Kadir Akin</a><br>
-  <a href="https://blog.fka.dev/textream/privacy.html">Privacy</a> · <a href="https://blog.fka.dev/textream/support.html">Support</a>
+  <a href="https://textream.net/privacy.html">Privacy</a> · <a href="https://textream.net/support.html">Support</a>
 </p>

--- a/Textream/Textream/ContentView.swift
+++ b/Textream/Textream/ContentView.swift
@@ -852,7 +852,7 @@ struct AboutView: View {
                     .clipShape(Capsule())
                 }
 
-                Link(destination: URL(string: "https://blog.fka.dev/textream/privacy.html")!) {
+                Link(destination: URL(string: "https://textream.net/privacy.html")!) {
                     HStack(spacing: 5) {
                         Image(systemName: "hand.raised.fill")
                             .font(.system(size: 11, weight: .semibold))

--- a/app-store/app-privacy.md
+++ b/app-store/app-privacy.md
@@ -6,7 +6,7 @@ This is a working draft for the App Store Connect questionnaire, not a completed
 
 - **Does this app collect data from this app?** No.
 - **Is any data used to track users?** No.
-- **Privacy Policy URL:** https://blog.fka.dev/textream/privacy.html
+- **Privacy Policy URL:** https://textream.net/privacy.html
 
 These proposed answers are based on the following build assumptions:
 

--- a/app-store/metadata/en-US/marketing_url.txt
+++ b/app-store/metadata/en-US/marketing_url.txt
@@ -1,1 +1,1 @@
-https://blog.fka.dev/textream/
+https://textream.net/

--- a/app-store/metadata/en-US/privacy_url.txt
+++ b/app-store/metadata/en-US/privacy_url.txt
@@ -1,1 +1,1 @@
-https://blog.fka.dev/textream/privacy.html
+https://textream.net/privacy.html

--- a/app-store/metadata/en-US/support_url.txt
+++ b/app-store/metadata/en-US/support_url.txt
@@ -1,1 +1,1 @@
-https://blog.fka.dev/textream/support.html
+https://textream.net/support.html

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+textream.net


### PR DESCRIPTION
## Summary
- configure GitHub Pages for textream.net
- update public privacy, support, marketing, and in-app policy URLs
- use textream.net as the generated Homebrew cask homepage

## Verification
- AppStore configuration builds successfully with code signing disabled
- git diff --check passes
- bundle identifiers and app identifiers are unchanged

Prepared and reviewed with Codex assistance.