### PR TITLE
Add App Store download to homepage

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -173,6 +173,26 @@
       color: var(--text3);
     }
 
+    .hero-brew {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      margin-bottom: 14px;
+      padding: 9px 14px;
+      background: rgba(255,255,255,0.035);
+      border: 1px solid rgba(255,255,255,0.07);
+      border-radius: 10px;
+      font-size: 12px;
+      color: var(--text3);
+    }
+
+    .hero-brew code {
+      font-family: 'SF Mono', 'Fira Code', monospace;
+      color: var(--accent2);
+      font-size: 12px;
+      user-select: all;
+    }
+
     /* App icon showcase */
     .icon-showcase {
       display: flex;
@@ -2259,7 +2279,12 @@
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
           Download for Mac
         </a>
+        <a href="https://apps.apple.com/app/textream/id6800061488" class="btn-secondary">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M16.7 13.1c0-2.4 2-3.6 2.1-3.7-1.1-1.7-2.9-1.9-3.5-1.9-1.5-.2-2.9.9-3.6.9-.7 0-1.8-.9-3-.9-1.5 0-3 .9-3.8 2.3-1.6 2.8-.4 7 1.1 9.3.8 1.1 1.7 2.3 2.9 2.2 1.2 0 1.6-.7 3.1-.7 1.4 0 1.9.7 3.1.7 1.3 0 2.1-1.1 2.8-2.2.9-1.3 1.2-2.6 1.2-2.6-.1 0-2.4-.9-2.4-3.4ZM14.3 5.9c.6-.8 1.1-1.9.9-3-.9 0-2.1.6-2.8 1.4-.6.7-1.1 1.8-1 2.9 1.1.1 2.2-.5 2.9-1.3Z"/></svg>
+          Download from App Store
+        </a>
       </div>
+      <div class="hero-brew"><span>Homebrew</span><code>brew install textream</code></div>
       <p class="dl-meta">macOS 15+ &middot; Apple Silicon &amp; Intel &middot; No sign-up required</p>
     </section>
 
@@ -3348,10 +3373,16 @@
     <section class="cta" id="download">
       <h2>Download Textream</h2>
       <p>Free. No sign-up. Just download, paste your script, and go.</p>
-      <a href="https://github.com/f/textream/releases/latest" class="btn-primary">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-        Download for Mac (.dmg)
-      </a>
+      <div class="hero-actions">
+        <a href="https://github.com/f/textream/releases/latest" class="btn-primary">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+          Download for Mac (.dmg)
+        </a>
+        <a href="https://apps.apple.com/app/textream/id6800061488" class="btn-secondary">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M16.7 13.1c0-2.4 2-3.6 2.1-3.7-1.1-1.7-2.9-1.9-3.5-1.9-1.5-.2-2.9.9-3.6.9-.7 0-1.8-.9-3-.9-1.5 0-3 .9-3.8 2.3-1.6 2.8-.4 7 1.1 9.3.8 1.1 1.7 2.3 2.9 2.2 1.2 0 1.6-.7 3.1-.7 1.4 0 1.9.7 3.1.7 1.3 0 2.1-1.1 2.8-2.2.9-1.3 1.2-2.6 1.2-2.6-.1 0-2.4-.9-2.4-3.4ZM14.3 5.9c.6-.8 1.1-1.9.9-3-.9 0-2.1.6-2.8 1.4-.6.7-1.1 1.8-1 2.9 1.1.1 2.2-.5 2.9-1.3Z"/></svg>
+          Download from App Store
+        </a>
+      </div>
       <p class="dl-meta" style="margin-top: 12px;">Requires macOS 15 Sequoia or later</p>
     </section>
 


### PR DESCRIPTION
## Summary
- add the live Mac App Store download beside the DMG in the hero and footer CTA
- show `brew install textream` in the hero as well as the existing Homebrew section
- preserve the existing responsive visual style

## Verification
- checked desktop and mobile layouts
- verified the App Store URL resolves
- `git diff --check`