### PR TITLE
Add configurable teleprompter reading options

### DIFF
--- a/Textream/Textream/ExternalDisplayController.swift
+++ b/Textream/Textream/ExternalDisplayController.swift
@@ -29,7 +29,13 @@ class ExternalDisplayController {
         return screens.first
     }
 
-    func show(speechRecognizer: SpeechRecognizer, words: [String], totalCharCount: Int, hasNextPage: Bool = false) {
+    func show(
+        speechRecognizer: SpeechRecognizer,
+        words: [String],
+        totalCharCount: Int,
+        paragraphBreakBeforeWordIndices: Set<Int> = [],
+        hasNextPage: Bool = false
+    ) {
         let settings = NotchSettings.shared
         guard settings.externalDisplayMode != .off else { return }
         guard let screen = targetScreen() else { return }
@@ -37,6 +43,7 @@ class ExternalDisplayController {
         dismiss()
 
         overlayContent.words = words
+        overlayContent.paragraphBreakBeforeWordIndices = paragraphBreakBeforeWordIndices
         overlayContent.totalCharCount = totalCharCount
         overlayContent.hasNextPage = hasNextPage
 
@@ -243,7 +250,11 @@ struct ExternalDisplayView: View {
                     },
                     smoothScroll: listeningMode != .wordTracking,
                     smoothWordProgress: timerWordProgress,
-                    isListening: isEffectivelyListening
+                    isListening: isEffectivelyListening,
+                    readingPosition: NotchSettings.shared.readingPosition,
+                    paragraphBreakBeforeWordIndices: NotchSettings.shared.showParagraphDividers
+                        ? content.paragraphBreakBeforeWordIndices
+                        : []
                 )
                 .padding(.horizontal, hPad)
 
@@ -258,7 +269,8 @@ struct ExternalDisplayView: View {
                     )
                     .frame(width: 240, height: 32)
 
-                    if listeningMode == .wordTracking {
+                    if listeningMode == .wordTracking,
+                       NotchSettings.shared.showLastSpokenWords {
                         Text(speechRecognizer.lastSpokenText.split(separator: " ").suffix(5).joined(separator: " "))
                             .font(.system(size: 18, weight: .medium))
                             .foregroundStyle(.white.opacity(0.5))

--- a/Textream/Textream/MarqueeTextView.swift
+++ b/Textream/Textream/MarqueeTextView.swift
@@ -143,6 +143,7 @@ struct SpeechScrollView: View {
     @State private var allowsNextBackwardTrackingUpdate = false
     @State private var hasAppliedTrackingTarget = false
     @State private var anchoredLayoutWidth: CGFloat = 0
+    @State private var anchoredParagraphBreakBeforeWordIndices: Set<Int> = []
 
     var body: some View {
         GeometryReader { geo in
@@ -176,16 +177,20 @@ struct SpeechScrollView: View {
             .onPreferenceChange(WordYPreferenceKey.self) { positions in
                 let wasEmpty = wordYPositions.isEmpty
                 let widthChanged = abs(anchoredLayoutWidth - geo.size.width) > 0.5
-                if widthChanged {
-                    stableTopLineCenter = nil
-                    stableLineAdvance = nil
+                let paragraphLayoutChanged = anchoredParagraphBreakBeforeWordIndices
+                    != paragraphBreakBeforeWordIndices
+                if widthChanged || paragraphLayoutChanged {
                     hasAppliedTrackingTarget = false
                 }
                 captureStableLineMetrics(from: positions)
                 wordYPositions = positions
-                // Re-anchor after a page switch or a width-driven text reflow.
-                if (wasEmpty || widthChanged) && !positions.isEmpty {
+                // Re-anchor after a page switch or any live layout reflow. Keep
+                // the stable vertical metrics during width changes: the visible
+                // preference values may be culled from the middle of the text.
+                if (wasEmpty || widthChanged || paragraphLayoutChanged),
+                   !positions.isEmpty {
                     anchoredLayoutWidth = geo.size.width
+                    anchoredParagraphBreakBeforeWordIndices = paragraphBreakBeforeWordIndices
                     recalculateTracking(containerHeight: containerHeight)
                 }
             }
@@ -228,6 +233,7 @@ struct SpeechScrollView: View {
                 allowsNextBackwardTrackingUpdate = false
                 hasAppliedTrackingTarget = false
                 anchoredLayoutWidth = 0
+                anchoredParagraphBreakBeforeWordIndices = []
             }
             .onChange(of: readingPosition) { _, _ in
                 manualOffset = 0

--- a/Textream/Textream/MarqueeTextView.swift
+++ b/Textream/Textream/MarqueeTextView.swift
@@ -7,6 +7,8 @@
 
 import SwiftUI
 
+private let paragraphDividerExtraSpacing: CGFloat = 4
+
 // MARK: - CJK-aware word splitting
 
 extension Unicode.Scalar {
@@ -56,6 +58,41 @@ func splitTextIntoWords(_ text: String) -> [String] {
     return result
 }
 
+/// Returns the word indices that begin a new paragraph. Consecutive and
+/// whitespace-only lines collapse into a single visual separator.
+func paragraphBreakWordIndices(in text: String) -> Set<Int> {
+    let normalizedLineEndings = text
+        .replacingOccurrences(of: "\r\n", with: "\n")
+        .replacingOccurrences(of: "\r", with: "\n")
+    let lines = normalizedLineEndings.split(
+        separator: "\n",
+        omittingEmptySubsequences: false
+    )
+
+    var result = Set<Int>()
+    var wordCount = 0
+    var hasContent = false
+    var hasPendingBreak = false
+
+    for (index, line) in lines.enumerated() {
+        let lineWords = splitTextIntoWords(String(line))
+        if !lineWords.isEmpty {
+            if hasContent && hasPendingBreak {
+                result.insert(wordCount)
+            }
+            wordCount += lineWords.count
+            hasContent = true
+            hasPendingBreak = false
+        }
+
+        if index < lines.count - 1, hasContent {
+            hasPendingBreak = true
+        }
+    }
+
+    return result
+}
+
 // MARK: - Data
 
 struct WordItem: Identifiable {
@@ -94,11 +131,17 @@ struct SpeechScrollView: View {
     var smoothWordProgress: Double = 0
 
     var isListening: Bool = true
+    var readingPosition: ReadingPosition = .centered
+    var paragraphBreakBeforeWordIndices: Set<Int> = []
     @State private var scrollOffset: CGFloat = 0
     @State private var manualOffset: CGFloat = 0
     @State private var wordYPositions: [Int: CGFloat] = [:]
     @State private var containerHeight: CGFloat = 0
     @State private var isUserScrolling: Bool = false
+    @State private var stableTopLineCenter: CGFloat?
+    @State private var stableLineAdvance: CGFloat?
+    @State private var allowsNextBackwardTrackingUpdate = false
+    @State private var hasAppliedTrackingTarget = false
 
     var body: some View {
         GeometryReader { geo in
@@ -111,24 +154,31 @@ struct SpeechScrollView: View {
                 cueUnreadOpacity: cueUnreadOpacity,
                 cueReadOpacity: cueReadOpacity,
                 highlightWords: !smoothScroll,
+                paragraphBreakBeforeWordIndices: paragraphBreakBeforeWordIndices,
                 containerWidth: geo.size.width,
                 onWordTap: { charOffset in
+                    let tappedWordIndex = wordIndex(at: charOffset)
                     manualOffset = 0
-                    onWordTap?(charOffset)
-                    // Force recenter on tapped word
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-                        recalcCenter(containerHeight: containerHeight)
+                    if charOffset < highlightedCharCount {
+                        allowsNextBackwardTrackingUpdate = true
                     }
+                    onWordTap?(charOffset)
+                    // Reposition from the tapped word itself instead of waiting
+                    // for the parent progress update. That update can arrive
+                    // after a stale recalculation has consumed the one-time
+                    // backward allowance.
+                    repositionTracking(toWordIndex: tappedWordIndex)
                 },
                 scrollOffset: scrollOffset + manualOffset,
                 viewportHeight: geo.size.height
             )
             .onPreferenceChange(WordYPreferenceKey.self) { positions in
                 let wasEmpty = wordYPositions.isEmpty
+                captureStableLineMetrics(from: positions)
                 wordYPositions = positions
                 // After a page switch, wordYPositions was cleared — recenter once new positions arrive
                 if wasEmpty && !positions.isEmpty {
-                    recalcCenter(containerHeight: containerHeight)
+                    recalculateTracking(containerHeight: containerHeight)
                 }
             }
             .offset(y: scrollOffset + manualOffset)
@@ -136,44 +186,54 @@ struct SpeechScrollView: View {
             .animation(.easeOut(duration: 0.15), value: manualOffset)
             .onChange(of: geo.size.height) { _, newHeight in
                 containerHeight = newHeight
+                hasAppliedTrackingTarget = false
                 if highlightedCharCount == 0 && smoothWordProgress == 0 {
-                    // Initial state: center first line on screen
-                    let lineHeight = font.pointSize * 1.4
-                    scrollOffset = newHeight * 0.5 - lineHeight * 0.5
+                    scrollOffset = initialScrollOffset(containerHeight: newHeight)
                 } else if isListening {
-                    recalcCenter(containerHeight: newHeight)
+                    recalculateTracking(containerHeight: newHeight)
                 }
             }
             .onChange(of: highlightedCharCount) { _, _ in
                 if isListening && !smoothScroll {
                     manualOffset = 0
-                    recalcCenter(containerHeight: containerHeight)
+                    recalculateTracking(containerHeight: containerHeight)
                 }
             }
             .onChange(of: smoothWordProgress) { _, _ in
                 if isListening && smoothScroll {
                     manualOffset = 0
-                    recalcCenter(containerHeight: containerHeight)
+                    recalculateTracking(containerHeight: containerHeight)
                 }
             }
             .onChange(of: isListening) { _, listening in
                 if listening {
                     manualOffset = 0
-                    recalcCenter(containerHeight: containerHeight)
+                    recalculateTracking(containerHeight: containerHeight)
                 }
             }
             .onChange(of: words) { _, _ in
-                // First line at vertical center: height/2 + lineHeight/2
-                let lineHeight = font.pointSize * 1.4
-                scrollOffset = containerHeight * 0.5 - lineHeight * 0.5
+                scrollOffset = initialScrollOffset(containerHeight: containerHeight)
                 manualOffset = 0
                 wordYPositions = [:]
+                stableTopLineCenter = nil
+                stableLineAdvance = nil
+                allowsNextBackwardTrackingUpdate = false
+                hasAppliedTrackingTarget = false
+            }
+            .onChange(of: readingPosition) { _, _ in
+                manualOffset = 0
+                stableTopLineCenter = nil
+                stableLineAdvance = nil
+                allowsNextBackwardTrackingUpdate = false
+                hasAppliedTrackingTarget = false
+                scrollOffset = initialScrollOffset(containerHeight: containerHeight)
+                DispatchQueue.main.async {
+                    recalculateTracking(containerHeight: containerHeight)
+                }
             }
             .onAppear {
                 containerHeight = geo.size.height
-                // First line at vertical center: height/2 + lineHeight/2
-                let lineHeight = font.pointSize * 1.4
-                scrollOffset = containerHeight * 0.5 - lineHeight * 0.5
+                scrollOffset = initialScrollOffset(containerHeight: containerHeight)
             }
             .overlay(
                 ScrollWheelView(
@@ -208,12 +268,13 @@ struct SpeechScrollView: View {
                     },
                     onScrollEnd: {
                         if smoothScroll && isUserScrolling {
-                            // Find the word at the new visual center
+                            // Find the word at the active tracking anchor.
                             let newProgress = wordProgressAtCurrentOffset()
                             withAnimation(.easeOut(duration: 0.15)) {
                                 manualOffset = 0
                             }
                             isUserScrolling = false
+                            allowsNextBackwardTrackingUpdate = true
                             onManualScroll?(false, newProgress)
                         } else {
                             let maxY = wordYPositions.values.max() ?? 0
@@ -234,19 +295,40 @@ struct SpeechScrollView: View {
         .clipped()
         .mask(
             LinearGradient(
-                stops: [
-                    .init(color: .clear, location: 0),
-                    .init(color: .white, location: 0.05),
-                    .init(color: .white, location: 0.95),
-                    .init(color: .clear, location: 1.0)
-                ],
+                stops: readingPosition == .nearTop
+                    ? [
+                        .init(color: .white, location: 0),
+                        .init(color: .white, location: 0.95),
+                        .init(color: .clear, location: 1.0)
+                    ]
+                    : [
+                        .init(color: .clear, location: 0),
+                        .init(color: .white, location: 0.05),
+                        .init(color: .white, location: 0.95),
+                        .init(color: .clear, location: 1.0)
+                    ],
                 startPoint: .top,
                 endPoint: .bottom
             )
         )
     }
 
-    private func recalcCenter(containerHeight: CGFloat) {
+    private func initialScrollOffset(containerHeight: CGFloat) -> CGFloat {
+        switch readingPosition {
+        case .centered:
+            let lineHeight = font.pointSize * 1.4
+            return containerHeight * 0.5 - lineHeight * 0.5
+        case .nearTop:
+            return 0
+        }
+    }
+
+    private func recalculateTracking(containerHeight: CGFloat) {
+        if readingPosition == .nearTop {
+            recalcTopWithPreviousLine()
+            return
+        }
+
         let center = containerHeight * 0.5
 
         if smoothScroll {
@@ -258,25 +340,119 @@ struct SpeechScrollView: View {
             guard let wordY = wordYPositions[clampedIdx] else { return }
             let nextY = wordYPositions[clampedIdx + 1] ?? wordY
             let interpolatedY = wordY + (nextY - wordY) * CGFloat(fraction)
-            scrollOffset = bottomAnchor - interpolatedY
+            applyTrackingTarget(bottomAnchor - interpolatedY)
         } else {
             // Word-tracking/voice-activated: active word at vertical center
             let wordIdx = activeWordIndex()
             if let wordY = wordYPositions[wordIdx] {
                 let target = center - wordY
-                // Only update if it actually changed to avoid redundant animations
-                if abs(scrollOffset - target) > 1 {
-                    scrollOffset = target
-                }
+                applyTrackingTarget(target)
             }
         }
     }
 
+    private func recalcTopWithPreviousLine() {
+        if smoothScroll {
+            let wordIdx = Int(smoothWordProgress)
+            let fraction = smoothWordProgress - Double(wordIdx)
+            let clampedIdx = max(0, min(wordIdx, words.count - 1))
+            guard let wordY = wordYPositions[clampedIdx] else { return }
+            let nextY = wordYPositions[clampedIdx + 1] ?? wordY
+            let interpolatedY = wordY + (nextY - wordY) * CGFloat(fraction)
+            let target = min(interpolatedY, topReadingAnchor) - interpolatedY
+            applyTrackingTarget(target)
+        } else {
+            let wordIdx = activeWordIndex()
+            guard let wordY = wordYPositions[wordIdx] else { return }
+            let target = min(wordY, topReadingAnchor) - wordY
+            applyTrackingTarget(target)
+        }
+    }
+
+    private func repositionTracking(toWordIndex wordIndex: Int) {
+        guard let wordY = wordYPositions[wordIndex] else { return }
+
+        let target: CGFloat
+        switch readingPosition {
+        case .centered:
+            target = containerHeight * 0.5 - wordY
+        case .nearTop:
+            target = min(wordY, topReadingAnchor) - wordY
+        }
+
+        applyTrackingTarget(target, force: true)
+    }
+
+    private var topReadingAnchor: CGFloat {
+        let lineHeight = ceil(font.ascender - font.descender + font.leading)
+        let fallbackAdvance = lineHeight + (lineHeight / font.pointSize > 1.5 ? 2 : 8)
+        return (stableTopLineCenter ?? lineHeight * 0.5)
+            + (stableLineAdvance ?? fallbackAdvance)
+    }
+
+    /// Capture the actual row geometry once, before visibility culling changes
+    /// which word frames participate in the preference dictionary.
+    private func captureStableLineMetrics(from positions: [Int: CGFloat]) {
+        guard readingPosition == .nearTop,
+              stableTopLineCenter == nil || stableLineAdvance == nil else { return }
+
+        let positionedWords = positions.sorted { $0.value < $1.value }
+        let measuredLines = positionedWords.reduce(into: [(y: CGFloat, wordIDs: [Int])]()) { result, entry in
+            if let lastIndex = result.indices.last,
+               abs(result[lastIndex].y - entry.value) <= 0.5 {
+                result[lastIndex].wordIDs.append(entry.key)
+            } else {
+                result.append((y: entry.value, wordIDs: [entry.key]))
+            }
+        }
+        guard let firstLineY = measuredLines.first?.y else { return }
+        if stableTopLineCenter == nil {
+            stableTopLineCenter = firstLineY
+        }
+        if stableLineAdvance == nil, measuredLines.count > 1 {
+            for index in 1..<measuredLines.count {
+                let firstWordID = measuredLines[index].wordIDs.min() ?? -1
+                guard !paragraphBreakBeforeWordIndices.contains(firstWordID) else { continue }
+                stableLineAdvance = measuredLines[index].y - measuredLines[index - 1].y
+                break
+            }
+        }
+    }
+
+    /// Normal reading progress may only move the text upward. Brief backward
+    /// corrections from speech recognition must not produce a down/up bounce.
+    /// Explicit taps and manual scrolling opt into one backward reposition.
+    private func applyTrackingTarget(_ target: CGFloat, force: Bool = false) {
+        if !hasAppliedTrackingTarget
+            || target < scrollOffset - 1
+            || allowsNextBackwardTrackingUpdate
+            || force {
+            scrollOffset = target
+        }
+        hasAppliedTrackingTarget = true
+        allowsNextBackwardTrackingUpdate = false
+    }
+
+    private func wordIndex(at charOffset: Int) -> Int {
+        var offset = 0
+        for (index, word) in words.enumerated() {
+            let end = offset + word.count
+            if charOffset <= end { return index }
+            offset = end + 1
+        }
+        return max(0, words.count - 1)
+    }
+
     /// Find the word progress at the current visual position (scrollOffset + manualOffset)
     private func wordProgressAtCurrentOffset() -> Double {
-        let center = containerHeight * 0.5
-        // The Y position currently at the center of the view
-        let targetY = center - (scrollOffset + manualOffset)
+        let trackingY: CGFloat
+        switch readingPosition {
+        case .centered:
+            trackingY = containerHeight * 0.5
+        case .nearTop:
+            trackingY = topReadingAnchor
+        }
+        let targetY = trackingY - (scrollOffset + manualOffset)
 
         // Find the closest word and interpolate
         let sorted = wordYPositions.sorted { $0.key < $1.key }
@@ -338,6 +514,7 @@ struct WordFlowLayout: View {
     var cueUnreadOpacity: Double = 0.2
     var cueReadOpacity: Double = 0.5
     var highlightWords: Bool = true
+    var paragraphBreakBeforeWordIndices: Set<Int> = []
     let containerWidth: CGFloat
     var onWordTap: ((Int) -> Void)? = nil
     var scrollOffset: CGFloat = 0
@@ -356,18 +533,32 @@ struct WordFlowLayout: View {
     private static var _cacheKey: String = ""
     private static var _cachedItems: [WordItem] = []
     private static var _cachedLines: [[WordItem]] = []
+    private static var _cachedParagraphPrefixCounts: [Int] = []
 
-    private func cachedLayout() -> ([WordItem], [[WordItem]]) {
-        let key = "\(words.count)|\(words.first ?? "")|\(words.last ?? "")|\(font.pointSize)|\(Int(containerWidth))"
+    private func cachedLayout() -> ([WordItem], [[WordItem]], [Int]) {
+        let paragraphKey = paragraphBreakBeforeWordIndices.sorted()
+            .map(String.init)
+            .joined(separator: ",")
+        let key = "\(words.count)|\(words.first ?? "")|\(words.last ?? "")|\(font.pointSize)|\(Int(containerWidth))|\(paragraphKey)"
         if key == Self._cacheKey {
-            return (Self._cachedItems, Self._cachedLines)
+            return (Self._cachedItems, Self._cachedLines, Self._cachedParagraphPrefixCounts)
         }
         let items = buildItems()
         let lines = buildLines(items: items)
+        var paragraphPrefixCounts = [0]
+        for line in lines {
+            let beginsParagraph = line.first.map {
+                paragraphBreakBeforeWordIndices.contains($0.id)
+            } ?? false
+            paragraphPrefixCounts.append(
+                paragraphPrefixCounts[paragraphPrefixCounts.count - 1] + (beginsParagraph ? 1 : 0)
+            )
+        }
         Self._cacheKey = key
         Self._cachedItems = items
         Self._cachedLines = lines
-        return (items, lines)
+        Self._cachedParagraphPrefixCounts = paragraphPrefixCounts
+        return (items, lines, paragraphPrefixCounts)
     }
 
     // Find the index of the next word to read (first non-fully-lit, non-annotation word)
@@ -399,39 +590,91 @@ struct WordFlowLayout: View {
     }
 
     var body: some View {
-        let (items, lines) = cachedLayout()
+        let (items, lines, paragraphPrefixCounts) = cachedLayout()
         let nextIdx = nextWordIndex(items: items)
         let totalLines = lines.count
         let rtl = isRightToLeft(items: items)
 
         // Estimate line height for visibility culling using actual font metrics
-        let lineH = ceil(font.ascender - font.descender + font.leading) + lineSpacing
+        let rowHeight = ceil(font.ascender - font.descender + font.leading)
+        let lineH = rowHeight + lineSpacing
+        let lineTop: (Int) -> CGFloat = { lineIndex in
+            CGFloat(lineIndex) * lineH
+                + CGFloat(paragraphPrefixCounts[lineIndex]) * paragraphDividerExtraSpacing
+        }
+        let lineRowHeight: (Int) -> CGFloat = { lineIndex in
+            let beginsParagraph = paragraphPrefixCounts[lineIndex + 1]
+                > paragraphPrefixCounts[lineIndex]
+            return rowHeight + (beginsParagraph ? paragraphDividerExtraSpacing : 0)
+        }
+        let totalContentHeight = max(0, lineTop(totalLines) - lineSpacing)
 
         // Determine visible range of lines
         let canCull = viewportHeight > 0 && totalLines > 0
         let buffer: CGFloat = 400
-        let startLine = canCull ? max(0, min(totalLines, Int(floor((-scrollOffset - buffer) / lineH)))) : 0
-        let endLine = canCull ? max(startLine, min(totalLines, Int(ceil((viewportHeight - scrollOffset + buffer) / lineH)))) : totalLines
+        let startLine: Int = {
+            guard canCull else { return 0 }
+            let visibleMinY = -scrollOffset - buffer
+            var candidate = max(0, min(totalLines, Int(floor(max(0, visibleMinY) / lineH))))
+            while candidate > 0, lineTop(candidate) > visibleMinY {
+                candidate -= 1
+            }
+            while candidate < totalLines,
+                  lineTop(candidate) + lineRowHeight(candidate) < visibleMinY {
+                candidate += 1
+            }
+            return candidate
+        }()
+        let endLine: Int = {
+            guard canCull else { return totalLines }
+            let visibleMaxY = viewportHeight - scrollOffset + buffer
+            var candidate = max(startLine, min(totalLines, Int(ceil(max(0, visibleMaxY) / lineH))))
+            while candidate > startLine, lineTop(candidate) > visibleMaxY {
+                candidate -= 1
+            }
+            while candidate < totalLines, lineTop(candidate) < visibleMaxY {
+                candidate += 1
+            }
+            return max(startLine, candidate)
+        }()
 
         // For RTL scripts (Arabic, Hebrew, Persian, Urdu), flip the layout direction
         // so words within each line flow right-to-left instead of left-to-right.
         VStack(alignment: rtl ? .trailing : .leading, spacing: lineSpacing) {
             if startLine > 0 {
-                Color.clear.frame(height: CGFloat(startLine) * lineH)
+                Color.clear.frame(
+                    height: max(0, lineTop(startLine) - lineSpacing)
+                )
             }
 
             ForEach(startLine..<endLine, id: \.self) { lineIdx in
+                let beginsParagraph = paragraphPrefixCounts[lineIdx + 1]
+                    > paragraphPrefixCounts[lineIdx]
                 HStack(spacing: 0) {
                     ForEach(lines[lineIdx], id: \.id) { item in
                         wordView(for: item, isNextWord: item.id == nextIdx)
                             .id(item.id)
                     }
                 }
+                .frame(maxWidth: .infinity, alignment: rtl ? .trailing : .leading)
+                .padding(.top, beginsParagraph ? paragraphDividerExtraSpacing : 0)
+                .overlay(alignment: .top) {
+                    if beginsParagraph {
+                        Rectangle()
+                            .fill(Color.white.opacity(0.2))
+                            .frame(height: 1)
+                            .offset(
+                                y: (paragraphDividerExtraSpacing - lineSpacing) * 0.5
+                            )
+                    }
+                }
                 .environment(\.layoutDirection, rtl ? .rightToLeft : .leftToRight)
             }
 
             if endLine < totalLines {
-                Color.clear.frame(height: CGFloat(totalLines - endLine) * lineH)
+                Color.clear.frame(
+                    height: max(0, totalContentHeight - lineTop(endLine))
+                )
             }
         }
         .frame(maxWidth: .infinity, alignment: rtl ? .trailing : .leading)
@@ -545,6 +788,11 @@ struct WordFlowLayout: View {
         let spaceWidth = (" " as NSString).size(withAttributes: [.font: font]).width
 
         for item in items {
+            if paragraphBreakBeforeWordIndices.contains(item.id),
+               !lines[lines.count - 1].isEmpty {
+                lines.append([])
+                currentLineWidth = 0
+            }
             let wordWidth = (item.word as NSString).size(withAttributes: [.font: font]).width + spaceWidth
             if currentLineWidth + wordWidth > containerWidth && !lines[lines.count - 1].isEmpty {
                 lines.append([])

--- a/Textream/Textream/MarqueeTextView.swift
+++ b/Textream/Textream/MarqueeTextView.swift
@@ -142,6 +142,7 @@ struct SpeechScrollView: View {
     @State private var stableLineAdvance: CGFloat?
     @State private var allowsNextBackwardTrackingUpdate = false
     @State private var hasAppliedTrackingTarget = false
+    @State private var anchoredLayoutWidth: CGFloat = 0
 
     var body: some View {
         GeometryReader { geo in
@@ -174,10 +175,17 @@ struct SpeechScrollView: View {
             )
             .onPreferenceChange(WordYPreferenceKey.self) { positions in
                 let wasEmpty = wordYPositions.isEmpty
+                let widthChanged = abs(anchoredLayoutWidth - geo.size.width) > 0.5
+                if widthChanged {
+                    stableTopLineCenter = nil
+                    stableLineAdvance = nil
+                    hasAppliedTrackingTarget = false
+                }
                 captureStableLineMetrics(from: positions)
                 wordYPositions = positions
-                // After a page switch, wordYPositions was cleared — recenter once new positions arrive
-                if wasEmpty && !positions.isEmpty {
+                // Re-anchor after a page switch or a width-driven text reflow.
+                if (wasEmpty || widthChanged) && !positions.isEmpty {
+                    anchoredLayoutWidth = geo.size.width
                     recalculateTracking(containerHeight: containerHeight)
                 }
             }
@@ -219,6 +227,7 @@ struct SpeechScrollView: View {
                 stableLineAdvance = nil
                 allowsNextBackwardTrackingUpdate = false
                 hasAppliedTrackingTarget = false
+                anchoredLayoutWidth = 0
             }
             .onChange(of: readingPosition) { _, _ in
                 manualOffset = 0

--- a/Textream/Textream/NotchOverlayController.swift
+++ b/Textream/Textream/NotchOverlayController.swift
@@ -33,6 +33,7 @@ class NotchFrameTracker {
 @Observable
 class OverlayContent {
     var words: [String] = []
+    var paragraphBreakBeforeWordIndices: Set<Int> = []
     var totalCharCount: Int = 0
     var hasNextPage: Bool = false
 
@@ -60,6 +61,7 @@ class NotchOverlayController: NSObject {
     private var currentScreenID: UInt32 = 0
     private var stopButtonPanel: NSPanel?
     private var escMonitor: Any?
+    private var keepAwakeActivity: NSObjectProtocol?
 
     func show(text: String, hasNextPage: Bool = false, onComplete: (() -> Void)? = nil) {
         self.onComplete = onComplete
@@ -73,6 +75,7 @@ class NotchOverlayController: NSObject {
         // Populate overlay content
         let normalized = splitTextIntoWords(text)
         overlayContent.words = normalized
+        overlayContent.paragraphBreakBeforeWordIndices = paragraphBreakWordIndices(in: text)
         overlayContent.totalCharCount = normalized.joined(separator: " ").count
         overlayContent.hasNextPage = hasNextPage
 
@@ -115,6 +118,12 @@ class NotchOverlayController: NSObject {
             showStopButton(on: screen)
         }
 
+        if settings.keepScreenAwake {
+            beginKeepAwakeActivity()
+        } else {
+            endKeepAwakeActivity()
+        }
+
         // Word tracking & silence-paused need the microphone; classic does not
         if settings.listeningMode != .classic {
             speechRecognizer.start(with: text)
@@ -131,6 +140,7 @@ class NotchOverlayController: NSObject {
         speechRecognizer.lastSpokenText = ""
 
         overlayContent.words = normalized
+        overlayContent.paragraphBreakBeforeWordIndices = paragraphBreakWordIndices(in: text)
         overlayContent.totalCharCount = normalized.joined(separator: " ").count
         overlayContent.hasNextPage = hasNextPage
 
@@ -219,7 +229,6 @@ class NotchOverlayController: NSObject {
     private func showPinned(settings: NotchSettings, screen: NSScreen) {
         let notchWidth = settings.notchWidth
         let textAreaHeight = settings.textAreaHeight
-        let maxExtraHeight: CGFloat = 350
         let screenFrame = screen.frame
         let visibleFrame = screen.visibleFrame
 
@@ -236,7 +245,12 @@ class NotchOverlayController: NSObject {
         self.frameTracker = tracker
         self.currentScreenID = screen.displayID
 
-        let overlayView = NotchOverlayView(content: overlayContent, speechRecognizer: speechRecognizer, menuBarHeight: menuBarHeight, baseTextHeight: textAreaHeight, maxExtraHeight: maxExtraHeight, frameTracker: tracker)
+        let overlayView = NotchOverlayView(
+            content: overlayContent,
+            speechRecognizer: speechRecognizer,
+            menuBarHeight: menuBarHeight,
+            frameTracker: tracker
+        )
         let contentView = NSHostingView(rootView: overlayView)
 
         // Start panel at full target size (SwiftUI animates the notch shape inside)
@@ -401,6 +415,7 @@ class NotchOverlayController: NSObject {
             self.panel?.orderOut(nil)
             self.panel = nil
             self.frameTracker = nil
+            self.endKeepAwakeActivity()
             self.speechRecognizer.shouldDismiss = false
             self.isDismissing = false
             self.onComplete?()
@@ -434,6 +449,7 @@ class NotchOverlayController: NSObject {
         panel?.orderOut(nil)
         panel = nil
         frameTracker = nil
+        endKeepAwakeActivity()
         speechRecognizer.shouldDismiss = false
         speechRecognizer.shouldAdvancePage = false
     }
@@ -470,12 +486,31 @@ class NotchOverlayController: NSObject {
                         self.panel?.orderOut(nil)
                         self.panel = nil
                         self.frameTracker = nil
+                        self.endKeepAwakeActivity()
                         self.speechRecognizer.shouldDismiss = false
                         self.onComplete?()
                     }
                 }
             }
             .store(in: &cancellables)
+    }
+
+    private func beginKeepAwakeActivity() {
+        endKeepAwakeActivity()
+        keepAwakeActivity = ProcessInfo.processInfo.beginActivity(
+            options: [
+                .userInitiated,
+                .idleSystemSleepDisabled,
+                .idleDisplaySleepDisabled
+            ],
+            reason: "Textream teleprompter reading session"
+        )
+    }
+
+    private func endKeepAwakeActivity() {
+        guard let keepAwakeActivity else { return }
+        ProcessInfo.processInfo.endActivity(keepAwakeActivity)
+        self.keepAwakeActivity = nil
     }
 
     var isShowing: Bool {
@@ -633,8 +668,6 @@ struct NotchOverlayView: View {
     @Bindable var content: OverlayContent
     @Bindable var speechRecognizer: SpeechRecognizer
     let menuBarHeight: CGFloat
-    let baseTextHeight: CGFloat
-    let maxExtraHeight: CGFloat
     var frameTracker: NotchFrameTracker
 
     private var words: [String] { content.words }
@@ -644,9 +677,7 @@ struct NotchOverlayView: View {
     // Animation state - 0.0 = notch size, 1.0 = full size
     @State private var expansion: CGFloat = 0
     @State private var contentVisible = false
-    @State private var extraHeight: CGFloat = 0
     @State private var dragStartHeight: CGFloat = -1
-    @State private var isHovering: Bool = false
 
     // Timer-based scroll for classic & silence-paused modes
     @State private var timerWordProgress: Double = 0
@@ -721,7 +752,7 @@ struct NotchOverlayView: View {
 
     var body: some View {
         GeometryReader { geo in
-            let targetHeight = menuBarHeight + baseTextHeight + extraHeight
+            let targetHeight = menuBarHeight + NotchSettings.shared.textAreaHeight
             let currentHeight = notchHeight + (targetHeight - notchHeight) * expansion
             let currentWidth = notchWidth + (geo.size.width - notchWidth) * expansion
 
@@ -784,7 +815,12 @@ struct NotchOverlayView: View {
             .frame(width: currentWidth, height: currentHeight, alignment: .top)
             .frame(width: geo.size.width, height: geo.size.height, alignment: .top)
         }
-        .onChange(of: extraHeight) { _, _ in updateFrameTracker() }
+        .onChange(of: NotchSettings.shared.textAreaHeight) { _, newHeight in
+            frameTracker.visibleHeight = menuBarHeight + newHeight
+        }
+        .onChange(of: NotchSettings.shared.notchWidth) { _, newWidth in
+            frameTracker.visibleWidth = newWidth
+        }
         .onAppear {
             // Phase 1: Expand container with smooth easing
             withAnimation(.easeOut(duration: 0.4)) {
@@ -855,13 +891,6 @@ struct NotchOverlayView: View {
         }
     }
 
-    private func updateFrameTracker() {
-        let targetHeight = menuBarHeight + baseTextHeight + extraHeight
-        let fullWidth = NotchSettings.shared.notchWidth
-        frameTracker.visibleHeight = targetHeight
-        frameTracker.visibleWidth = fullWidth
-    }
-
     private var isEffectivelyListening: Bool {
         switch listeningMode {
         case .wordTracking, .silencePaused:
@@ -896,7 +925,11 @@ struct NotchOverlayView: View {
                 },
                 smoothScroll: listeningMode != .wordTracking,
                 smoothWordProgress: timerWordProgress,
-                isListening: isEffectivelyListening
+                isListening: isEffectivelyListening,
+                readingPosition: NotchSettings.shared.readingPosition,
+                paragraphBreakBeforeWordIndices: NotchSettings.shared.showParagraphDividers
+                    ? content.paragraphBreakBeforeWordIndices
+                    : []
             )
             .padding(.horizontal, 12)
             .padding(.top, 6)
@@ -921,7 +954,8 @@ struct NotchOverlayView: View {
                         .truncationMode(.tail)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .help(error)
-                } else if listeningMode == .wordTracking {
+                } else if listeningMode == .wordTracking,
+                          NotchSettings.shared.showLastSpokenWords {
                     Text(speechRecognizer.lastSpokenText.split(separator: " ").suffix(3).joined(separator: " "))
                         .font(.system(size: 11, weight: .medium))
                         .foregroundStyle(.white.opacity(0.5))
@@ -1025,47 +1059,42 @@ struct NotchOverlayView: View {
             }
             .frame(height: 24)
             .padding(.horizontal, 12)
-            .padding(.bottom, 10)
+            .padding(.bottom, 2)
 
-            // Resize handle - only visible on hover
-            if isHovering {
-                VStack(spacing: 0) {
-                    Spacer().frame(height: 4)
-                    RoundedRectangle(cornerRadius: 2)
-                        .fill(Color.white.opacity(0.25))
-                        .frame(width: 36, height: 4)
-                    Spacer().frame(height: 8)
-                }
-                .frame(height: 16)
-                .frame(maxWidth: .infinity)
-                .contentShape(Rectangle())
-                .simultaneousGesture(
-                    DragGesture(minimumDistance: 2, coordinateSpace: .global)
-                        .onChanged { value in
-                            if dragStartHeight < 0 {
-                                dragStartHeight = extraHeight
-                            }
-                            let newExtra = dragStartHeight + value.translation.height
-                            extraHeight = max(0, min(maxExtraHeight, newExtra))
+            // Keep the resize handle in the layout at all times to avoid hover-driven shifts.
+            VStack(spacing: 0) {
+                Spacer().frame(height: 2)
+                RoundedRectangle(cornerRadius: 2)
+                    .fill(Color.white.opacity(0.25))
+                    .frame(width: 36, height: 4)
+                Spacer().frame(height: 4)
+            }
+            .frame(height: 10)
+            .frame(maxWidth: .infinity)
+            .contentShape(Rectangle())
+            .simultaneousGesture(
+                DragGesture(minimumDistance: 2, coordinateSpace: .global)
+                    .onChanged { value in
+                        if dragStartHeight < 0 {
+                            dragStartHeight = NotchSettings.shared.textAreaHeight
                         }
-                        .onEnded { _ in
-                            dragStartHeight = -1
-                        }
-                )
-                .onHover { hovering in
-                    if hovering {
-                        NSCursor.resizeUpDown.push()
-                    } else {
-                        NSCursor.pop()
+                        let newHeight = dragStartHeight + value.translation.height
+                        NotchSettings.shared.textAreaHeight = max(
+                            NotchSettings.minHeight,
+                            min(NotchSettings.maxHeight, newHeight)
+                        )
                     }
-                }
-                .transition(.move(edge: .bottom).combined(with: .opacity))
-            }
-            }
+                    .onEnded { _ in
+                        dragStartHeight = -1
+                    }
+            )
             .onHover { hovering in
-                withAnimation(.easeInOut(duration: 0.2)) {
-                    isHovering = hovering
+                if hovering {
+                    NSCursor.resizeUpDown.push()
+                } else {
+                    NSCursor.pop()
                 }
+            }
             }
             .transition(.opacity)
         }
@@ -1393,7 +1422,11 @@ struct FloatingOverlayView: View {
                 },
                 smoothScroll: listeningMode != .wordTracking,
                 smoothWordProgress: timerWordProgress,
-                isListening: isEffectivelyListening
+                isListening: isEffectivelyListening,
+                readingPosition: NotchSettings.shared.readingPosition,
+                paragraphBreakBeforeWordIndices: NotchSettings.shared.showParagraphDividers
+                    ? content.paragraphBreakBeforeWordIndices
+                    : []
             )
             .padding(.horizontal, 16)
             .padding(.top, 12)
@@ -1415,7 +1448,8 @@ struct FloatingOverlayView: View {
                         .truncationMode(.tail)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .help(error)
-                } else if listeningMode == .wordTracking {
+                } else if listeningMode == .wordTracking,
+                          NotchSettings.shared.showLastSpokenWords {
                     Text(speechRecognizer.lastSpokenText.split(separator: " ").suffix(3).joined(separator: " "))
                         .font(.system(size: 11, weight: .medium))
                         .foregroundStyle(.white.opacity(0.5))

--- a/Textream/Textream/NotchOverlayController.swift
+++ b/Textream/Textream/NotchOverlayController.swift
@@ -118,11 +118,7 @@ class NotchOverlayController: NSObject {
             showStopButton(on: screen)
         }
 
-        if settings.keepScreenAwake {
-            beginKeepAwakeActivity()
-        } else {
-            endKeepAwakeActivity()
-        }
+        updateKeepAwakeActivity(enabled: settings.keepScreenAwake)
 
         // Word tracking & silence-paused need the microphone; classic does not
         if settings.listeningMode != .classic {
@@ -511,6 +507,14 @@ class NotchOverlayController: NSObject {
         guard let keepAwakeActivity else { return }
         ProcessInfo.processInfo.endActivity(keepAwakeActivity)
         self.keepAwakeActivity = nil
+    }
+
+    func updateKeepAwakeActivity(enabled: Bool) {
+        if enabled && isShowing {
+            beginKeepAwakeActivity()
+        } else {
+            endKeepAwakeActivity()
+        }
     }
 
     var isShowing: Bool {

--- a/Textream/Textream/NotchSettings.swift
+++ b/Textream/Textream/NotchSettings.swift
@@ -313,6 +313,21 @@ enum ListeningMode: String, CaseIterable, Identifiable {
     }
 }
 
+// MARK: - Reading Position
+
+enum ReadingPosition: String, CaseIterable, Identifiable {
+    case centered, nearTop
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .centered: return "Centered"
+        case .nearTop:  return "Near Top"
+        }
+    }
+}
+
 // MARK: - Settings
 
 @Observable
@@ -411,6 +426,22 @@ class NotchSettings {
         didSet { UserDefaults.standard.set(showElapsedTime, forKey: "showElapsedTime") }
     }
 
+    var keepScreenAwake: Bool {
+        didSet { UserDefaults.standard.set(keepScreenAwake, forKey: "keepScreenAwake") }
+    }
+
+    var readingPosition: ReadingPosition {
+        didSet { UserDefaults.standard.set(readingPosition.rawValue, forKey: "readingPosition") }
+    }
+
+    var showParagraphDividers: Bool {
+        didSet { UserDefaults.standard.set(showParagraphDividers, forKey: "showParagraphDividers") }
+    }
+
+    var showLastSpokenWords: Bool {
+        didSet { UserDefaults.standard.set(showLastSpokenWords, forKey: "showLastSpokenWords") }
+    }
+
     var selectedMicUID: String {
         didSet { UserDefaults.standard.set(selectedMicUID, forKey: "selectedMicUID") }
     }
@@ -496,6 +527,10 @@ class NotchSettings {
         self.scrollSpeed = savedSpeed > 0 ? savedSpeed : 3
         self.hideFromScreenShare = UserDefaults.standard.object(forKey: "hideFromScreenShare") as? Bool ?? true
         self.showElapsedTime = UserDefaults.standard.object(forKey: "showElapsedTime") as? Bool ?? true
+        self.keepScreenAwake = UserDefaults.standard.object(forKey: "keepScreenAwake") as? Bool ?? false
+        self.readingPosition = ReadingPosition(rawValue: UserDefaults.standard.string(forKey: "readingPosition") ?? "") ?? .centered
+        self.showParagraphDividers = UserDefaults.standard.object(forKey: "showParagraphDividers") as? Bool ?? false
+        self.showLastSpokenWords = UserDefaults.standard.object(forKey: "showLastSpokenWords") as? Bool ?? true
         self.selectedMicUID = UserDefaults.standard.string(forKey: "selectedMicUID") ?? ""
         self.autoNextPage = UserDefaults.standard.object(forKey: "autoNextPage") as? Bool ?? false
         let savedDelay = UserDefaults.standard.integer(forKey: "autoNextPageDelay")

--- a/Textream/Textream/NotchSettings.swift
+++ b/Textream/Textream/NotchSettings.swift
@@ -427,7 +427,10 @@ class NotchSettings {
     }
 
     var keepScreenAwake: Bool {
-        didSet { UserDefaults.standard.set(keepScreenAwake, forKey: "keepScreenAwake") }
+        didSet {
+            UserDefaults.standard.set(keepScreenAwake, forKey: "keepScreenAwake")
+            TextreamService.shared.updateKeepAwakeActivity(enabled: keepScreenAwake)
+        }
     }
 
     var readingPosition: ReadingPosition {

--- a/Textream/Textream/SettingsView.swift
+++ b/Textream/Textream/SettingsView.swift
@@ -160,7 +160,9 @@ struct NotchPreviewContent: View {
     @Bindable var settings: NotchSettings
     let menuBarHeight: CGFloat
 
-    private static let loremWords = "Lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor [pause] incididunt ut labore et dolore magna aliqua Ut enim ad minim veniam quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur Excepteur sint occaecat cupidatat non proident sunt in culpa qui officia deserunt mollit anim id est laborum Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium totam rem aperiam eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt".split(separator: " ").map(String.init)
+    private static let loremText = "Lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor [pause] incididunt ut labore et dolore magna aliqua\nUt enim ad minim veniam quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur\nExcepteur sint occaecat cupidatat non proident sunt in culpa qui officia deserunt mollit anim id est laborum Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium totam rem aperiam eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt"
+    private static let loremWords = splitTextIntoWords(loremText)
+    private static let paragraphBreaks = paragraphBreakWordIndices(in: loremText)
 
     private let highlightedCount = 42
     @State private var previewWordProgress: Double = 0
@@ -242,7 +244,11 @@ struct NotchPreviewContent: View {
                         cueReadOpacity: settings.cueBrightness.readOpacity,
                         smoothScroll: settings.listeningMode != .wordTracking,
                         smoothWordProgress: previewWordProgress,
-                        isListening: settings.listeningMode != .wordTracking
+                        isListening: settings.listeningMode != .wordTracking,
+                        readingPosition: settings.readingPosition,
+                        paragraphBreakBeforeWordIndices: settings.showParagraphDividers
+                            ? Self.paragraphBreaks
+                            : []
                     )
                     .padding(.horizontal, 16)
                     .padding(.top, 10)
@@ -952,6 +958,65 @@ struct SettingsView: View {
 
                 Divider()
 
+                // Reading Experience
+                Text("Reading Experience")
+                    .font(.system(size: 13, weight: .semibold))
+
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack {
+                        Text("Reading Position")
+                            .font(.system(size: 13, weight: .medium))
+                        Spacer()
+                        Picker("", selection: $settings.readingPosition) {
+                            ForEach(ReadingPosition.allCases) { position in
+                                Text(position.label).tag(position)
+                            }
+                        }
+                        .pickerStyle(.segmented)
+                        .labelsHidden()
+                        .frame(width: 190)
+                    }
+
+                    Text("Near Top keeps the previous line visible above the active line.")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                }
+
+                Toggle(isOn: $settings.showParagraphDividers) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Show Paragraph Dividers")
+                            .font(.system(size: 13, weight: .medium))
+                        Text("Start a new row and draw a subtle divider at source line breaks.")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .toggleStyle(.checkbox)
+
+                Toggle(isOn: $settings.showLastSpokenWords) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Show Last Spoken Words")
+                            .font(.system(size: 13, weight: .medium))
+                        Text("Display recently recognized words while using Word Tracking.")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .toggleStyle(.checkbox)
+
+                Toggle(isOn: $settings.keepScreenAwake) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Keep Screen Awake")
+                            .font(.system(size: 13, weight: .medium))
+                        Text("Prevent display and system sleep while the teleprompter is active.")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .toggleStyle(.checkbox)
+
+                Divider()
+
                 // Options
                 Toggle(isOn: $settings.showElapsedTime) {
                     VStack(alignment: .leading, spacing: 2) {
@@ -1419,6 +1484,10 @@ struct SettingsView: View {
         settings.listeningMode = .wordTracking
         settings.scrollSpeed = 3
         settings.showElapsedTime = true
+        settings.keepScreenAwake = false
+        settings.readingPosition = .centered
+        settings.showParagraphDividers = false
+        settings.showLastSpokenWords = true
         settings.selectedMicUID = ""
         settings.autoNextPage = false
         settings.autoNextPageDelay = 3

--- a/Textream/Textream/TextreamService.swift
+++ b/Textream/Textream/TextreamService.swift
@@ -443,6 +443,10 @@ class TextreamService: NSObject, ObservableObject {
         directorIsReading = false
     }
 
+    func updateKeepAwakeActivity(enabled: Bool) {
+        overlayController.updateKeepAwakeActivity(enabled: enabled)
+    }
+
     // macOS Services handler
     @objc func readInTextream(_ pboard: NSPasteboard, userData: String, error: AutoreleasingUnsafeMutablePointer<NSString?>) {
         guard let text = pboard.string(forType: .string) else {

--- a/Textream/Textream/TextreamService.swift
+++ b/Textream/Textream/TextreamService.swift
@@ -55,10 +55,12 @@ class TextreamService: NSObject, ObservableObject {
         // Also show on external display if configured (same parsing as overlay)
         let words = splitTextIntoWords(trimmed)
         let totalCharCount = words.joined(separator: " ").count
+        let paragraphBreaks = paragraphBreakWordIndices(in: trimmed)
         externalDisplayController.show(
             speechRecognizer: overlayController.speechRecognizer,
             words: words,
             totalCharCount: totalCharCount,
+            paragraphBreakBeforeWordIndices: paragraphBreaks,
             hasNextPage: hasNextPage
         )
 
@@ -115,6 +117,7 @@ class TextreamService: NSObject, ObservableObject {
         // Also update external display content in-place
         let words = splitTextIntoWords(trimmed)
         externalDisplayController.overlayContent.words = words
+        externalDisplayController.overlayContent.paragraphBreakBeforeWordIndices = paragraphBreakWordIndices(in: trimmed)
         externalDisplayController.overlayContent.totalCharCount = words.joined(separator: " ").count
         externalDisplayController.overlayContent.hasNextPage = hasNextPage
 
@@ -378,10 +381,12 @@ class TextreamService: NSObject, ObservableObject {
         )
 
         // Also show on external display & browser if configured
+        let paragraphBreaks = paragraphBreakWordIndices(in: trimmed)
         externalDisplayController.show(
             speechRecognizer: overlayController.speechRecognizer,
             words: words,
             totalCharCount: totalCharCount,
+            paragraphBreakBeforeWordIndices: paragraphBreaks,
             hasNextPage: false
         )
         if browserServer.isRunning {
@@ -409,6 +414,7 @@ class TextreamService: NSObject, ObservableObject {
 
         // Update overlay content without resetting speech progress
         overlayController.overlayContent.words = words
+        overlayController.overlayContent.paragraphBreakBeforeWordIndices = paragraphBreakWordIndices(in: trimmed)
         overlayController.overlayContent.totalCharCount = totalCharCount
         overlayController.overlayContent.hasNextPage = false
 
@@ -420,6 +426,7 @@ class TextreamService: NSObject, ObservableObject {
 
         // Update external display & browser
         externalDisplayController.overlayContent.words = words
+        externalDisplayController.overlayContent.paragraphBreakBeforeWordIndices = paragraphBreakWordIndices(in: trimmed)
         externalDisplayController.overlayContent.totalCharCount = totalCharCount
         if browserServer.isRunning {
             browserServer.updateContent(


### PR DESCRIPTION
## Summary

Adds configurable reading-experience options for Textream’s local teleprompter overlays while preserving the existing upstream behavior by default.

The changes apply to pinned notch, floating, fullscreen, external-display, and Director-opened local overlays. Browser and Director web outputs are intentionally unchanged.

## Reading Experience Settings

Adds four persistent options under **Teleprompter → Reading Experience**:

| Option | Default |
| --- | --- |
| Keep Screen Awake | Off |
| Reading Position: Centered / Near Top | Centered |
| Show Paragraph Dividers | Off |
| Show Last Spoken Words | On |

The settings are stored using `UserDefaults` and restored to their original defaults by **Reset All**.

## Reading and Tracking Improvements

- Adds a **Near Top** reading position that keeps the preceding line visible
- Stabilizes automatic scrolling against backward speech-recognition revisions
- Prevents distracting up/down scroll oscillation during normal reading
- Allows intentional backward navigation by tapping a previous word
- Immediately repositions the scroll view to the tapped word instead of allowing the forward-only stabilization guard to block it
- Preserves intentional manual scrolling in the applicable reading modes
- Shows last spoken words only in Word Tracking mode and only when enabled

## Paragraph Dividers

- Converts source newlines into subtle, spaced paragraph dividers when enabled
- Collapses consecutive or empty lines into a single divider
- Preserves upstream whitespace behavior when disabled
- Propagates paragraph metadata during initial presentation, page transitions, and Director live-text updates
- Updates the Settings preview live

## Overlay Resizing

- Keeps the compact drag handle permanently visible without hover-driven layout shifts
- Reduces unnecessary spacing around the handle
- Applies Width changes immediately to an already-open notch overlay
- Synchronizes Height bidirectionally:
  - Dragging the resize handle updates the persisted Height setting
  - Changing Height in Settings immediately updates the open overlay and handle position
- Keeps the pinned overlay anchored and centered while its dimensions change

## Keep Screen Awake

When enabled, Textream creates a macOS activity assertion while the teleprompter is active.

The assertion is released across:

- Normal close
- Forced close
- Automatic dismissal
- Overlay replacement

No assertion is created when the option is disabled.

## Scope

Supported local surfaces:

- Pinned notch
- Floating overlay
- Fullscreen
- External display
- Local overlays opened through Director

Not included:

- Browser output
- Director web output

## Validation

- [x] macOS Debug build with code signing disabled
- [x] `git diff --check`
- [x] Default values preserve existing behavior
- [x] Settings persist across relaunch
- [x] Keep-awake assertion is created and released correctly
- [x] Reading-position and paragraph-divider behavior verified
- [x] Verify backward word jumps in both Centered and Near Top modes
- [x] Verify live Width and Height changes while the notch overlay is open
- [x] Verify drag-handle Height changes are reflected in Settings
- [x] Verify pinned, floating, fullscreen behavior

---

_Generated by 5.6 Sol Extra High_