### PR TITLE
Start the prompter with ⌘↩ from the main window

### DIFF
--- a/Textream/Textream/ContentView.swift
+++ b/Textream/Textream/ContentView.swift
@@ -596,6 +596,13 @@ Happy presenting! [wave]
         .sheet(isPresented: $showAbout) {
             AboutView()
         }
+        .onReceive(NotificationCenter.default.publisher(for: .startPrompter)) { _ in
+            // ⌘↩ from the editor. The main window hides while the prompter runs,
+            // so this only ever starts; Esc stops from the overlay.
+            guard !isRunning, !isRecording, hasAnyContent else { return }
+            isTextFocused = false
+            run()
+        }
         .onReceive(NotificationCenter.default.publisher(for: .openSettings)) { _ in
             showSettings = true
         }

--- a/Textream/Textream/TextreamApp.swift
+++ b/Textream/Textream/TextreamApp.swift
@@ -10,6 +10,7 @@ import SwiftUI
 extension Notification.Name {
     static let openSettings = Notification.Name("openSettings")
     static let openAbout = Notification.Name("openAbout")
+    static let startPrompter = Notification.Name("startPrompter")
 }
 
 class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
@@ -168,6 +169,13 @@ struct TextreamApp: App {
                     TextreamService.shared.saveFileAs()
                 }
                 .keyboardShortcut("s", modifiers: [.command, .shift])
+
+                Divider()
+
+                Button("Start Prompter") {
+                    NotificationCenter.default.post(name: .startPrompter, object: nil)
+                }
+                .keyboardShortcut(.return, modifiers: .command)
             }
             CommandGroup(replacing: .windowArrangement) { }
             CommandGroup(replacing: .help) {


### PR DESCRIPTION
## Summary

Starting a script means reaching for the play button, even though the cursor is already in the editor. This adds a **File → Start Prompter** command bound to ⌘↩.

It is wired as a menu command rather than a key handler on the text view, so the shortcut takes priority over the editor and fires while typing instead of being swallowed as a newline. It also gives the action a discoverable menu entry.

Starts only. The main window hides while the prompter runs, so there is nothing to press it in; Esc still stops from the overlay. No-op when the script is empty or dictation is recording.

## Testing

Built and run on macOS 26. Verified ⌘↩ starts the prompter with the caret in the editor, that it does nothing on an empty script or while dictating, and that the menu item appears under File.