### PR TITLE
Adapt download links for iPhone and iPad

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -174,6 +174,8 @@
       box-shadow: 0 8px 32px rgba(124, 106, 255, 0.4);
     }
 
+    [hidden] { display: none !important; }
+
     .dl-meta {
       font-size: 13px;
       color: var(--text3);
@@ -2344,17 +2346,17 @@
       <p class="subtitle">Textream is a free, open-source teleprompter app with three guidance modes: real-time word tracking, classic auto-scroll, and voice-activated scrolling. It displays an elegant Dynamic Island overlay at the top of your screen &mdash; or as a floating window, or fullscreen on a Sidecar iPad. Invisible to your audience, always visible to you.</p>
       <p class="use-cases">Built for <span>streamers</span> &middot; <span>interviewers</span> &middot; <span>presenters</span> &middot; <span>podcasters</span> &middot; <span>content creators</span></p>
       <div class="hero-actions">
-        <a href="https://github.com/f/textream/releases/latest" class="btn-primary">
+        <a href="https://github.com/f/textream/releases/latest" class="btn-primary" data-platform-download>
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-          Download for Mac
+          <span data-platform-download-label>Download for Mac</span>
         </a>
-        <a href="https://apps.apple.com/app/textream/id6800061488" class="btn-secondary">
+        <a href="https://apps.apple.com/app/textream/id6800061488" class="btn-secondary" data-app-store-download>
           <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M16.7 13.1c0-2.4 2-3.6 2.1-3.7-1.1-1.7-2.9-1.9-3.5-1.9-1.5-.2-2.9.9-3.6.9-.7 0-1.8-.9-3-.9-1.5 0-3 .9-3.8 2.3-1.6 2.8-.4 7 1.1 9.3.8 1.1 1.7 2.3 2.9 2.2 1.2 0 1.6-.7 3.1-.7 1.4 0 1.9.7 3.1.7 1.3 0 2.1-1.1 2.8-2.2.9-1.3 1.2-2.6 1.2-2.6-.1 0-2.4-.9-2.4-3.4ZM14.3 5.9c.6-.8 1.1-1.9.9-3-.9 0-2.1.6-2.8 1.4-.6.7-1.1 1.8-1 2.9 1.1.1 2.2-.5 2.9-1.3Z"/></svg>
           Download on the App Store
         </a>
       </div>
-      <div class="hero-brew"><span>Homebrew</span><code>brew install textream</code></div>
-      <p class="dl-meta">macOS 15+ &middot; iOS 26+ &middot; No sign-up required</p>
+      <div class="hero-brew" data-desktop-install><span>Homebrew</span><code>brew install textream</code></div>
+      <p class="dl-meta" data-platform-requirements data-iphone-copy="iOS 26+ · No sign-up required" data-ipad-copy="iPadOS 26+ · No sign-up required">macOS 15+ &middot; iOS 26+ &middot; No sign-up required</p>
     </section>
 
     <!-- Animated Demo -->
@@ -3443,20 +3445,20 @@
       <h2>Download Textream</h2>
       <p>Free. No sign-up. Just download, paste your script, and go.</p>
       <div class="hero-actions">
-        <a href="https://github.com/f/textream/releases/latest" class="btn-primary">
+        <a href="https://github.com/f/textream/releases/latest" class="btn-primary" data-platform-download>
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-          Download for Mac (.dmg)
+          <span data-platform-download-label>Download for Mac (.dmg)</span>
         </a>
-        <a href="https://apps.apple.com/app/textream/id6800061488" class="btn-secondary">
+        <a href="https://apps.apple.com/app/textream/id6800061488" class="btn-secondary" data-app-store-download>
           <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M16.7 13.1c0-2.4 2-3.6 2.1-3.7-1.1-1.7-2.9-1.9-3.5-1.9-1.5-.2-2.9.9-3.6.9-.7 0-1.8-.9-3-.9-1.5 0-3 .9-3.8 2.3-1.6 2.8-.4 7 1.1 9.3.8 1.1 1.7 2.3 2.9 2.2 1.2 0 1.6-.7 3.1-.7 1.4 0 1.9.7 3.1.7 1.3 0 2.1-1.1 2.8-2.2.9-1.3 1.2-2.6 1.2-2.6-.1 0-2.4-.9-2.4-3.4ZM14.3 5.9c.6-.8 1.1-1.9.9-3-.9 0-2.1.6-2.8 1.4-.6.7-1.1 1.8-1 2.9 1.1.1 2.2-.5 2.9-1.3Z"/></svg>
           Download on the App Store
         </a>
       </div>
-      <p class="dl-meta download-requirements">Requires macOS 15 or iOS/iPadOS 26</p>
+      <p class="dl-meta download-requirements" data-platform-requirements data-iphone-copy="Requires iOS 26" data-ipad-copy="Requires iPadOS 26">Requires macOS 15 or iOS/iPadOS 26</p>
     </section>
 
     <!-- Install via Homebrew -->
-    <div class="install-note">
+    <div class="install-note" data-desktop-install>
       <h3>Install via Homebrew</h3>
       <p>You can also install Textream using Homebrew:</p>
       <code>brew install textream</code>
@@ -3468,5 +3470,38 @@
       <p>Made by <a href="https://fka.dev">Fatih Kadir Akin</a> &middot; <a href="/docs/">Docs</a> &middot; <a href="https://github.com/f/textream">Source on GitHub</a> &middot; <a href="privacy.html">Privacy</a> &middot; <a href="support.html">Support</a></p>
     </footer>
   </div>
+
+  <script>
+    (function adaptDownloadButtonsForAppleMobile() {
+      var userAgent = navigator.userAgent || '';
+      var platform = navigator.platform || '';
+      var isIPad = /iPad/i.test(userAgent) || (platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+      var isIPhone = /iPhone|iPod/i.test(userAgent);
+
+      if (!isIPad && !isIPhone) return;
+
+      var device = isIPad ? 'iPad' : 'iPhone';
+      var requirementKey = isIPad ? 'ipadCopy' : 'iphoneCopy';
+      var appStoreURL = 'https://apps.apple.com/app/textream/id6800061488';
+      var appleIcon = '<svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M16.7 13.1c0-2.4 2-3.6 2.1-3.7-1.1-1.7-2.9-1.9-3.5-1.9-1.5-.2-2.9.9-3.6.9-.7 0-1.8-.9-3-.9-1.5 0-3 .9-3.8 2.3-1.6 2.8-.4 7 1.1 9.3.8 1.1 1.7 2.3 2.9 2.2 1.2 0 1.6-.7 3.1-.7 1.4 0 1.9.7 3.1.7 1.3 0 2.1-1.1 2.8-2.2.9-1.3 1.2-2.6 1.2-2.6-.1 0-2.4-.9-2.4-3.4ZM14.3 5.9c.6-.8 1.1-1.9.9-3-.9 0-2.1.6-2.8 1.4-.6.7-1.1 1.8-1 2.9 1.1.1 2.2-.5 2.9-1.3Z"/></svg>';
+
+      document.documentElement.dataset.downloadPlatform = device.toLowerCase();
+
+      document.querySelectorAll('[data-platform-download]').forEach(function(link) {
+        link.href = appStoreURL;
+        link.setAttribute('aria-label', 'Download Textream for ' + device + ' on the App Store');
+        link.querySelector('svg').outerHTML = appleIcon;
+        link.querySelector('[data-platform-download-label]').textContent = 'Download for ' + device;
+      });
+
+      document.querySelectorAll('[data-app-store-download], [data-desktop-install]').forEach(function(element) {
+        element.hidden = true;
+      });
+
+      document.querySelectorAll('[data-platform-requirements]').forEach(function(element) {
+        element.textContent = element.dataset[requirementKey];
+      });
+    })();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- detect iPhone and iPad visitors, including iPadOS desktop-mode user agents
- turn both primary download actions into device-specific App Store links
- remove duplicate App Store and desktop-only Homebrew actions on those devices
- tailor the minimum OS copy for iOS and iPadOS

## Verification
- `npx html-validate docs/index.html`
- `git diff --check`
- DOM simulation for Mac, iPhone, iPad, and iPadOS desktop-mode user agents