### PR TITLE
Fix: Only show the settings preview for Pinned mode, and never mid-session

### DIFF
--- a/Textream/Textream/SettingsView.swift
+++ b/Textream/Textream/SettingsView.swift
@@ -485,14 +485,7 @@ struct SettingsView: View {
             Text("This will restore all settings to their defaults.")
         }
         .onAppear {
-            if settings.overlayMode != .fullscreen {
-                previewController.show(settings: settings)
-                if settings.followCursorWhenUndocked && settings.overlayMode == .floating {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                        previewController.animateToCursor(settings: settings)
-                    }
-                }
-            }
+            showPreviewIfIdle(settings)
         }
         .onDisappear {
             previewController.dismiss()
@@ -501,14 +494,7 @@ struct SettingsView: View {
             previewController.hide()
         }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
-            if settings.overlayMode != .fullscreen {
-                previewController.show(settings: settings)
-                if settings.followCursorWhenUndocked && settings.overlayMode == .floating {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                        previewController.animateToCursor(settings: settings)
-                    }
-                }
-            }
+            showPreviewIfIdle(settings)
         }
         .onChange(of: settings.followCursorWhenUndocked) { _, follow in
             if follow && settings.overlayMode == .floating {
@@ -518,7 +504,7 @@ struct SettingsView: View {
             }
         }
         .onChange(of: settings.overlayMode) { _, mode in
-            if mode == .fullscreen {
+            if mode != .pinned || isPrompterRunning {
                 previewController.hide()
             } else {
                 previewController.show(settings: settings)
@@ -527,6 +513,25 @@ struct SettingsView: View {
                 } else if previewController.isAtCursor {
                     previewController.animateFromCursor()
                 }
+            }
+        }
+    }
+
+    /// The preview panel is drawn at the notch, always on top, and ignores
+    /// mouse events. That only makes sense for Pinned mode: in Floating mode it
+    /// previews at a position the overlay will never occupy and sits over the
+    /// settings window, and during a live session it reads as a second,
+    /// undraggable prompter running the wrong script.
+    private var isPrompterRunning: Bool {
+        TextreamService.shared.overlayController.isShowing
+    }
+
+    private func showPreviewIfIdle(_ settings: NotchSettings) {
+        guard !isPrompterRunning, settings.overlayMode == .pinned else { return }
+        previewController.show(settings: settings)
+        if settings.followCursorWhenUndocked && settings.overlayMode == .floating {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                previewController.animateToCursor(settings: settings)
             }
         }
     }


### PR DESCRIPTION
## Summary

`NotchPreviewController` draws its panel at the notch, at `.statusBar` level, with `ignoresMouseEvents = true`. All three call sites guard only on `overlayMode != .fullscreen`, which lets it through in two cases where it misleads:

**Floating mode.** The preview appears at the notch — a position the floating window will never occupy — and the panel then sits over the settings window and hides the controls behind it. This got more noticeable in 1.7.0, since the new Reading tab made the settings window tall enough to reach into the preview's space.

**During a live session.** Opening Settings while the prompter is running puts the preview on top of the real overlay. It shows the canned "Good morning…" script and a second elapsed timer, and because it ignores mouse events it cannot be dragged out of the way — so it reads as a second prompter that has lost your script.

This restricts the preview to Pinned mode, where it previews the real overlay position and stays clear of the settings window, and holds it back while a session is running.

## Reproducing on master

1. Settings → Teleprompter → **Floating Window**.
2. Reopen Settings. The preview panel covers the upper part of the settings window.
3. Start the prompter, then press ⌘, — a second, undraggable prompter appears running the wrong script.

## Testing

Built and run on macOS 26. Verified the preview still appears and tracks settings changes in Pinned mode, no longer appears in Floating or Fullscreen, and never appears while a session is running.