### PR TITLE
Fix crash with high-rate audio inputs

### DIFF
--- a/Textream/Textream/DictationManager.swift
+++ b/Textream/Textream/DictationManager.swift
@@ -213,13 +213,10 @@ class DictationManager {
             return
         }
 
-        let monoFormat = AVAudioFormat(
-            commonFormat: recordingFormat.commonFormat,
-            sampleRate: recordingFormat.sampleRate,
-            channels: 1,
-            interleaved: recordingFormat.isInterleaved
-        )
-        let tapFormat = recordingFormat.channelCount > 1 ? monoFormat : recordingFormat
+        guard let tapFormat = speechCaptureFormat(for: recordingFormat) else {
+            fail("Audio input format is unsupported.")
+            return
+        }
 
         // Observe audio configuration changes
         configurationChangeObserver = NotificationCenter.default.addObserver(
@@ -235,8 +232,19 @@ class DictationManager {
 
         inputNode.removeTap(onBus: 0)
 
-        inputNode.installTap(onBus: 0, bufferSize: 1024, format: tapFormat) { [weak self] buffer, _ in
+        let waveformFrameInterval = AVAudioFrameCount(max(1, tapFormat.sampleRate / 20.0))
+        var framesSinceWaveformUpdate = waveformFrameInterval
+
+        inputNode.installTap(
+            onBus: 0,
+            bufferSize: speechCaptureBufferSize(for: tapFormat),
+            format: tapFormat
+        ) { [weak self] buffer, _ in
             self?.appendBuffer(buffer)
+
+            framesSinceWaveformUpdate &+= buffer.frameLength
+            guard framesSinceWaveformUpdate >= waveformFrameInterval else { return }
+            framesSinceWaveformUpdate %= waveformFrameInterval
 
             guard let channelData = buffer.floatChannelData?[0] else { return }
             let frameLength = Int(buffer.frameLength)

--- a/Textream/Textream/SpeechRecognizer.swift
+++ b/Textream/Textream/SpeechRecognizer.swift
@@ -11,6 +11,27 @@ import Speech
 import AVFoundation
 import CoreAudio
 
+private let waveformUpdatesPerSecond = 20.0
+private let speechCaptureBuffersPerSecond = 40.0
+
+func speechCaptureFormat(for hardwareFormat: AVAudioFormat) -> AVAudioFormat? {
+    guard hardwareFormat.channelCount > 1 else { return hardwareFormat }
+
+    // An input-node tap must use the hardware sample rate. AVAudioEngine can
+    // downmix channels here, but requesting a different rate raises an
+    // uncaught AVFAudio format-mismatch exception on high-rate USB devices.
+    return AVAudioFormat(
+        commonFormat: .pcmFormatFloat32,
+        sampleRate: hardwareFormat.sampleRate,
+        channels: 1,
+        interleaved: false
+    )
+}
+
+func speechCaptureBufferSize(for format: AVAudioFormat) -> AVAudioFrameCount {
+    AVAudioFrameCount(max(1024, format.sampleRate / speechCaptureBuffersPerSecond))
+}
+
 struct AudioInputDevice: Identifiable, Hashable {
     let id: AudioDeviceID
     let uid: String
@@ -469,16 +490,12 @@ class SpeechRecognizer {
             return
         }
 
-        // SFSpeechRecognizer requires mono audio. Multi-channel devices (e.g.
-        // RODECaster Pro II at 2ch/48kHz) cause the recognition task to silently
-        // return no results. Request a mono tap and let AVAudioEngine downmix.
-        let monoFormat = AVAudioFormat(
-            commonFormat: hardwareFormat.commonFormat,
-            sampleRate: hardwareFormat.sampleRate,
-            channels: 1,
-            interleaved: hardwareFormat.isInterleaved
-        )
-        let tapFormat = (hardwareFormat.channelCount > 1) ? monoFormat : hardwareFormat
+        // SFSpeechRecognizer expects mono voice audio. Downmix multi-channel
+        // devices without changing the input node's hardware sample rate.
+        guard let tapFormat = speechCaptureFormat(for: hardwareFormat) else {
+            failListening("Audio input format is unsupported.")
+            return
+        }
 
         // Observe audio configuration changes (e.g. mic switched externally) to restart gracefully
         configurationChangeObserver = NotificationCenter.default.addObserver(
@@ -496,8 +513,21 @@ class SpeechRecognizer {
         // Belt-and-suspenders: ensure no stale tap exists before installing
         inputNode.removeTap(onBus: 0)
 
-        inputNode.installTap(onBus: 0, bufferSize: 1024, format: tapFormat) { [weak self] buffer, _ in
+        let waveformFrameInterval = AVAudioFrameCount(
+            max(1, tapFormat.sampleRate / waveformUpdatesPerSecond)
+        )
+        var framesSinceWaveformUpdate = waveformFrameInterval
+
+        inputNode.installTap(
+            onBus: 0,
+            bufferSize: speechCaptureBufferSize(for: tapFormat),
+            format: tapFormat
+        ) { [weak self] buffer, _ in
             self?.appendBufferToRequest(buffer)
+
+            framesSinceWaveformUpdate &+= buffer.frameLength
+            guard framesSinceWaveformUpdate >= waveformFrameInterval else { return }
+            framesSinceWaveformUpdate %= waveformFrameInterval
 
             guard let channelData = buffer.floatChannelData?[0] else { return }
             let frameLength = Int(buffer.frameLength)


### PR DESCRIPTION
## Summary

Fixes the uncaught AVFAudio format-mismatch crash that can occur when starting the prompter or dictation with a high-sample-rate, multichannel USB input.

Closes #106.

## Root cause

`AVAudioEngine` input-node taps can downmix channels, but they must retain the input node's hardware sample rate. A tap configured as mono 48 kHz against a 2-channel 192 kHz Focusrite input raised an Objective-C exception inside `installTap`, terminating the app with `SIGABRT`.

At 192 kHz, the fixed 1,024-frame buffer also allowed roughly 187.5 callbacks and main-thread waveform publications per second, contributing to audio overload and recursive layout warnings.

## Changes

- Centralize speech capture format selection.
- Preserve the hardware sample rate while downmixing multichannel input to mono.
- Request capture buffers sized for approximately 40 callbacks per second, with a 1,024-frame minimum.
- Publish observable waveform levels at no more than 20 updates per second.
- Use the same capture behavior in `SpeechRecognizer` and `DictationManager`.

## Verification

- Compiled all macOS Swift sources with Swift 5 against the macOS 26 SDK, targeting macOS 15.
- Built and ad-hoc signed a local app bundle using Command Line Tools because full Xcode is not installed on the reproduction machine.
- Ran the exact 10-page reproduction document for 2 minutes 39 seconds with a Focusrite Scarlett Solo USB configured as 2-channel, 192 kHz input.
- Confirmed the runtime audio path was `2 ch, 192000 Hz -> 1 ch, 192000 Hz -> 1 ch, 16000 Hz` for speech processing.
- Confirmed no format-mismatch exception, `SIGABRT`, CoreAudio overload-skip message, or recursive `layoutSubtreeIfNeeded` warning during the patched run.
- `git diff --check` passed.

## Notes

CoreAudio `-10877` messages still appear during Focusrite device reconfiguration. They also occurred in non-crashing runs and were not the terminating condition; the causal failure was the tap format mismatch.

The document contents and local filesystem path are intentionally omitted. The issue includes the relevant structure, hardware state, crash reason, and stack location without publishing private script content.
