### PR TITLE
Remember the last document directory

### DIFF
--- a/Textream/Textream/ContentView.swift
+++ b/Textream/Textream/ContentView.swift
@@ -790,6 +790,7 @@ Happy presenting! [wave]
                     service.currentPageIndex = 0
                     service.readPages.removeAll()
                     service.currentFileURL = nil
+                    service.rememberDocumentURL(url)
                     isImporting = false
                 }
             } catch {

--- a/Textream/Textream/TextreamService.swift
+++ b/Textream/Textream/TextreamService.swift
@@ -12,6 +12,7 @@ import UniformTypeIdentifiers
 
 class TextreamService: NSObject, ObservableObject {
     static let shared = TextreamService()
+    private static let lastDocumentURLDefaultsKey = "lastDocumentURL"
     let overlayController = NotchOverlayController()
     let externalDisplayController = ExternalDisplayController()
     let browserServer = BrowserServer()
@@ -172,6 +173,27 @@ class TextreamService: NSObject, ObservableObject {
 
     // MARK: - File Operations
 
+    private var lastDocumentDirectoryURL: URL? {
+        guard let path = UserDefaults.standard.string(forKey: Self.lastDocumentURLDefaultsKey),
+              !path.isEmpty else { return nil }
+
+        let directoryURL = URL(fileURLWithPath: path).deletingLastPathComponent()
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(
+            atPath: directoryURL.path,
+            isDirectory: &isDirectory
+        ), isDirectory.boolValue else { return nil }
+        return directoryURL
+    }
+
+    func rememberDocumentURL(_ url: URL) {
+        guard url.isFileURL else { return }
+        UserDefaults.standard.set(
+            url.standardizedFileURL.path,
+            forKey: Self.lastDocumentURLDefaultsKey
+        )
+    }
+
     func saveFile() {
         if let url = currentFileURL {
             saveToURL(url)
@@ -185,6 +207,8 @@ class TextreamService: NSObject, ObservableObject {
         panel.allowedContentTypes = [.init(filenameExtension: "textream")!]
         panel.nameFieldStringValue = "Untitled.textream"
         panel.canCreateDirectories = true
+        panel.directoryURL = currentFileURL?.deletingLastPathComponent()
+            ?? lastDocumentDirectoryURL
 
         panel.begin { [weak self] response in
             guard response == .OK, let url = panel.url else { return }
@@ -198,6 +222,7 @@ class TextreamService: NSObject, ObservableObject {
             try data.write(to: url, options: .atomic)
             currentFileURL = url
             savedPages = pages
+            rememberDocumentURL(url)
             NSDocumentController.shared.noteNewRecentDocumentURL(url)
         } catch {
             let alert = NSAlert()
@@ -222,6 +247,8 @@ class TextreamService: NSObject, ObservableObject {
         ]
         panel.allowsMultipleSelection = false
         panel.canChooseDirectories = false
+        panel.directoryURL = currentFileURL?.deletingLastPathComponent()
+            ?? lastDocumentDirectoryURL
 
         panel.begin { [weak self] response in
             guard response == .OK, let url = panel.url else { return }
@@ -250,6 +277,7 @@ class TextreamService: NSObject, ObservableObject {
                     self?.currentPageIndex = 0
                     self?.readPages.removeAll()
                     self?.currentFileURL = nil
+                    self?.rememberDocumentURL(url)
                 }
             } catch {
                 DispatchQueue.main.async {
@@ -297,6 +325,7 @@ class TextreamService: NSObject, ObservableObject {
             currentPageIndex = 0
             readPages.removeAll()
             currentFileURL = url
+            rememberDocumentURL(url)
             NSDocumentController.shared.noteNewRecentDocumentURL(url)
         } catch {
             let alert = NSAlert()


### PR DESCRIPTION
Closes #108.

## Summary

- persist the last successfully opened, imported, or saved document path
- initialize Open and Save As panels from that document's existing parent folder
- include direct `.textream` opens and PowerPoint imports, including drag and drop
- fall back to the normal system panel location when the remembered folder no longer exists

This does not automatically reopen the previous document; it only restores the file chooser location.

## Verification

- compiled the complete macOS app from the committed sources with the macOS 15 SDK
- verified the ad-hoc app bundle signature and `Info.plist`
- opened a `.textream` document from a dedicated scripts folder and confirmed the persisted `lastDocumentURL`
- quit/relaunched the app, invoked Open, and confirmed the native panel returned to that folder and displayed its documents
- `git diff --check`