### PR TITLE
Keep prompter controls interactive while app is inactive

### DIFF
--- a/Textream/Textream/ExternalDisplayController.swift
+++ b/Textream/Textream/ExternalDisplayController.swift
@@ -58,7 +58,7 @@ class ExternalDisplayController {
 
         let hostingView = NSHostingView(rootView: content)
 
-        let panel = NSPanel(
+        let panel = PrompterPanel(
             contentRect: screenFrame,
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,

--- a/Textream/Textream/NotchOverlayController.swift
+++ b/Textream/Textream/NotchOverlayController.swift
@@ -9,6 +9,13 @@ import AppKit
 import SwiftUI
 import Combine
 
+/// A nonactivating panel that can still receive keyboard and control events.
+/// This keeps the prompter interactive while another app (for example, a
+/// screen recorder) remains the active application.
+final class PrompterPanel: NSPanel {
+    override var canBecomeKey: Bool { true }
+}
+
 @Observable
 class NotchFrameTracker {
     var visibleHeight: CGFloat = 37 {
@@ -253,7 +260,7 @@ class NotchOverlayController: NSObject {
         let targetHeight = menuBarHeight + textAreaHeight
         let targetY = screenFrame.maxY - targetHeight
         let xPosition = screenFrame.midX - notchWidth / 2
-        let panel = NSPanel(
+        let panel = PrompterPanel(
             contentRect: NSRect(x: xPosition, y: targetY, width: notchWidth, height: targetHeight),
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
@@ -301,7 +308,7 @@ class NotchOverlayController: NSObject {
         )
         let contentView = NSHostingView(rootView: floatingView)
 
-        let panel = NSPanel(
+        let panel = PrompterPanel(
             contentRect: initialFrame,
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
@@ -333,7 +340,7 @@ class NotchOverlayController: NSObject {
         )
         let contentView = NSHostingView(rootView: fullscreenView)
 
-        let panel = NSPanel(
+        let panel = PrompterPanel(
             contentRect: screenFrame,
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
@@ -368,7 +375,7 @@ class NotchOverlayController: NSObject {
         )
         let contentView = NSHostingView(rootView: floatingView)
 
-        let panel = NSPanel(
+        let panel = PrompterPanel(
             contentRect: NSRect(x: xPosition, y: yPosition, width: panelWidth, height: panelHeight),
             styleMask: [.borderless, .nonactivatingPanel, .resizable],
             backing: .buffered,
@@ -538,7 +545,7 @@ class NotchOverlayController: NSObject {
             self.dismiss()
         })
 
-        let panel = NSPanel(
+        let panel = PrompterPanel(
             contentRect: NSRect(x: x, y: y, width: buttonSize, height: buttonSize),
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,


### PR DESCRIPTION
## Summary

- add a key-capable `PrompterPanel` subclass for nonactivating prompter windows
- use it for notch, floating, fullscreen, stop-control, and dedicated external-display panels
- keep the current nonactivating behavior so Textream does not activate the whole app during a recording or presentation

Closes #110.

## Why

Stock borderless `NSPanel` instances configured with `.nonactivatingPanel` report `canBecomeKeyWindow = false`. When Textream hides its editor and another app owns focus, the prompter has no key window, so **Next Page** clicks and the local Escape monitor can stop responding even though the UI timer is still running.

## Verification

- full macOS source typecheck with `swiftc`
- runtime check: both live prompter panels were `PrompterPanel`, `canBecomeKeyWindow = true`, and `ignoresMouseEvents = false`
- with Cap foreground, a two-page fixture advanced from page 1 to page 2 through **Next Page**
- page 2 restarted speech capture successfully on a 192 kHz Focusrite input
- process remained alive with no format-mismatch exception or termination event

## Risk

Low. The change only affects whether existing nonactivating panels can become key for input delivery; their window level, screen placement, sharing behavior, and activation style are unchanged.
