### PR TITLE
Prevent external quit during active prompting

### DIFF
--- a/Textream/Textream/TextreamApp.swift
+++ b/Textream/Textream/TextreamApp.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import OSLog
 
 extension Notification.Name {
     static let openSettings = Notification.Name("openSettings")
@@ -14,6 +15,11 @@ extension Notification.Name {
 }
 
 class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
+    private let lifecycleLogger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "dev.fka.textream",
+        category: "AppLifecycle"
+    )
+
     func applicationWillFinishLaunching(_ notification: Notification) {
         NSWindow.allowsAutomaticWindowTabbing = false
         let launchedByURL: Bool
@@ -77,6 +83,28 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         }
         NSApp.terminate(nil)
         return false
+    }
+
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        guard
+            TextreamService.shared.overlayController.isShowing,
+            let event = NSAppleEventManager.shared().currentAppleEvent,
+            event.eventClass == kCoreEventClass,
+            event.eventID == kAEQuitApplication,
+            event.paramDescriptor(forKeyword: kAEQuitReason) == nil
+        else {
+            return .terminateNow
+        }
+
+        let senderPID = event.attributeDescriptor(forKeyword: keySenderPIDAttr)?.int32Value ?? 0
+        let runningApplication = NSRunningApplication(processIdentifier: pid_t(senderPID))
+        let senderName = runningApplication?.localizedName ?? "unknown"
+        let senderBundleIdentifier = runningApplication?.bundleIdentifier ?? "unknown"
+
+        lifecycleLogger.warning(
+            "Blocked external quit while teleprompter is active; senderPID=\(senderPID, privacy: .public) sender=\(senderName, privacy: .public) bundleIdentifier=\(senderBundleIdentifier, privacy: .public)"
+        )
+        return .terminateCancel
     }
 
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {


### PR DESCRIPTION
Closes #112.

## Summary

Textream can receive a reasonless Quit Application AppleEvent immediately after Play when another recording app is active. AppKit's default delegate response is to approve termination, so the process exits cleanly and produces no crash report.

This adds a narrow `applicationShouldTerminate(_:)` guard:

- Cancel a Quit Application AppleEvent only while the teleprompter overlay is active and the event has no system quit reason.
- Continue allowing ordinary termination when the teleprompter is inactive.
- Continue honoring shutdown, restart, and logout events carrying `kAEQuitReason`.
- Log the sender PID, application name, and bundle identifier when a quit is blocked, providing evidence for identifying the originating process.

## Verification

- Type-checked all Swift sources with the command-line macOS SDK. (`#Preview` was removed only from a temporary staging copy because the Command Line Tools installation does not include the preview macro plugin.)
- Built and ad-hoc signed a local integration app containing this change.
- Started the exact multi-page document that previously failed while Cap 0.5.9 was recording; the teleprompter remained active.
- Sent the active app a real external termination request with `NSRunningApplication.terminate()`. The request was accepted by Launch Services, Textream stayed alive, and the new `AppLifecycle` log recorded the blocked sender PID.

## Tradeoff

A normal external Quit request from Finder or the Dock is also ignored while prompting. Stop the teleprompter first, then quit. System session termination remains allowed.
