### PR TITLE
Add shorter Auto Next Page delays

### DIFF
--- a/Textream/Textream/ExternalDisplayController.swift
+++ b/Textream/Textream/ExternalDisplayController.swift
@@ -53,7 +53,8 @@ class ExternalDisplayController {
         let content = ExternalDisplayView(
             content: overlayContent,
             speechRecognizer: speechRecognizer,
-            mirrorAxis: mirrorAxis
+            mirrorAxis: mirrorAxis,
+            handlesAutoNextPage: false
         )
 
         let hostingView = NSHostingView(rootView: content)
@@ -115,6 +116,7 @@ struct ExternalDisplayView: View {
     @Bindable var content: OverlayContent
     @Bindable var speechRecognizer: SpeechRecognizer
     let mirrorAxis: MirrorAxis?
+    let handlesAutoNextPage: Bool
 
     private var words: [String] { content.words }
     private var totalCharCount: Int { content.totalCharCount }
@@ -123,6 +125,8 @@ struct ExternalDisplayView: View {
     // Timer-based scroll for classic & silence-paused modes
     @State private var timerWordProgress: Double = 0
     @State private var isUserScrolling: Bool = false
+    @State private var countdownRemaining: Int = 0
+    @State private var countdownTimer: Timer? = nil
     private let scrollTimer = Timer.publish(every: 0.05, on: .main, in: .common).autoconnect()
 
     private var listeningMode: ListeningMode {
@@ -199,10 +203,18 @@ struct ExternalDisplayView: View {
         .scaleEffect(x: mirrorAxis?.scaleX ?? 1, y: mirrorAxis?.scaleY ?? 1)
         .animation(.easeInOut(duration: 0.5), value: isDone)
         .onChange(of: isDone) { _, done in
-            if done && listeningMode == .wordTracking {
-                speechRecognizer.stop()
+            if done {
+                if listeningMode == .wordTracking {
+                    speechRecognizer.stop()
+                }
+                if handlesAutoNextPage && hasNextPage && NotchSettings.shared.autoNextPage {
+                    startCountdown()
+                }
+            } else {
+                cancelCountdown()
             }
         }
+        .onDisappear { cancelCountdown() }
         .onReceive(scrollTimer) { _ in
             guard !isDone, !isUserScrolling else { return }
             let speed = NotchSettings.shared.scrollSpeed // words per second
@@ -216,6 +228,11 @@ struct ExternalDisplayView: View {
             case .wordTracking:
                 break
             }
+        }
+        .onChange(of: content.currentPageIndex) { _, _ in
+            timerWordProgress = 0
+            isUserScrolling = false
+            cancelCountdown()
         }
     }
 
@@ -252,11 +269,12 @@ struct ExternalDisplayView: View {
                     smoothWordProgress: timerWordProgress,
                     isListening: isEffectivelyListening,
                     readingPosition: NotchSettings.shared.readingPosition,
-                    paragraphBreakBeforeWordIndices: NotchSettings.shared.showParagraphDividers
-                        ? content.paragraphBreakBeforeWordIndices
-                        : []
-                )
-                .padding(.horizontal, hPad)
+                paragraphBreakBeforeWordIndices: NotchSettings.shared.showParagraphDividers
+                    ? content.paragraphBreakBeforeWordIndices
+                    : []
+            )
+            .id(content.currentPageIndex)
+            .padding(.horizontal, hPad)
 
                 Spacer().frame(height: 20)
 
@@ -308,7 +326,15 @@ struct ExternalDisplayView: View {
     private var doneView: some View {
         VStack(spacing: 12) {
             if hasNextPage {
+                if countdownRemaining > 0 {
+                    Text("\(countdownRemaining)")
+                        .font(.system(size: 40, weight: .heavy, design: .rounded))
+                        .foregroundStyle(.white)
+                        .contentTransition(.numericText())
+                        .animation(.easeInOut(duration: 0.3), value: countdownRemaining)
+                }
                 Button {
+                    cancelCountdown()
                     speechRecognizer.shouldAdvancePage = true
                 } label: {
                     HStack(spacing: 12) {
@@ -334,5 +360,33 @@ struct ExternalDisplayView: View {
             }
         }
         .transition(.scale.combined(with: .opacity))
+    }
+
+    private func startCountdown() {
+        countdownTimer?.invalidate()
+        countdownRemaining = NotchSettings.shared.autoNextPageDelay
+        guard countdownRemaining > 0 else {
+            countdownTimer = nil
+            DispatchQueue.main.async {
+                speechRecognizer.shouldAdvancePage = true
+            }
+            return
+        }
+        countdownTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { timer in
+            DispatchQueue.main.async {
+                countdownRemaining -= 1
+                if countdownRemaining <= 0 {
+                    timer.invalidate()
+                    countdownTimer = nil
+                    speechRecognizer.shouldAdvancePage = true
+                }
+            }
+        }
+    }
+
+    private func cancelCountdown() {
+        countdownTimer?.invalidate()
+        countdownTimer = nil
+        countdownRemaining = 0
     }
 }

--- a/Textream/Textream/NotchOverlayController.swift
+++ b/Textream/Textream/NotchOverlayController.swift
@@ -329,7 +329,8 @@ class NotchOverlayController: NSObject {
         let fullscreenView = ExternalDisplayView(
             content: overlayContent,
             speechRecognizer: speechRecognizer,
-            mirrorAxis: nil
+            mirrorAxis: nil,
+            handlesAutoNextPage: true
         )
         let contentView = NSHostingView(rootView: fullscreenView)
 
@@ -895,6 +896,10 @@ struct NotchOverlayView: View {
         .onChange(of: content.totalCharCount) { _, _ in
             timerWordProgress = 0
         }
+        .onChange(of: content.currentPageIndex) { _, _ in
+            timerWordProgress = 0
+            isUserScrolling = false
+        }
     }
 
     private var isEffectivelyListening: Bool {
@@ -937,6 +942,7 @@ struct NotchOverlayView: View {
                     ? content.paragraphBreakBeforeWordIndices
                     : []
             )
+            .id(content.currentPageIndex)
             .padding(.horizontal, 12)
             .padding(.top, 6)
             .mask {
@@ -1170,6 +1176,13 @@ struct NotchOverlayView: View {
     private func startCountdown() {
         countdownTimer?.invalidate()
         countdownRemaining = NotchSettings.shared.autoNextPageDelay
+        guard countdownRemaining > 0 else {
+            countdownTimer = nil
+            DispatchQueue.main.async {
+                speechRecognizer.shouldAdvancePage = true
+            }
+            return
+        }
         countdownTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { timer in
             DispatchQueue.main.async {
                 countdownRemaining -= 1
@@ -1413,6 +1426,10 @@ struct FloatingOverlayView: View {
         .onChange(of: content.totalCharCount) { _, _ in
             timerWordProgress = 0
         }
+        .onChange(of: content.currentPageIndex) { _, _ in
+            timerWordProgress = 0
+            isUserScrolling = false
+        }
     }
 
     private var floatingPrompterView: some View {
@@ -1446,6 +1463,7 @@ struct FloatingOverlayView: View {
                     ? content.paragraphBreakBeforeWordIndices
                     : []
             )
+            .id(content.currentPageIndex)
             .padding(.horizontal, 16)
             .padding(.top, 12)
 
@@ -1580,6 +1598,13 @@ struct FloatingOverlayView: View {
     private func startCountdown() {
         countdownTimer?.invalidate()
         countdownRemaining = NotchSettings.shared.autoNextPageDelay
+        guard countdownRemaining > 0 else {
+            countdownTimer = nil
+            DispatchQueue.main.async {
+                speechRecognizer.shouldAdvancePage = true
+            }
+            return
+        }
         countdownTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { timer in
             DispatchQueue.main.async {
                 countdownRemaining -= 1

--- a/Textream/Textream/NotchSettings.swift
+++ b/Textream/Textream/NotchSettings.swift
@@ -537,7 +537,10 @@ class NotchSettings {
         self.selectedMicUID = UserDefaults.standard.string(forKey: "selectedMicUID") ?? ""
         self.autoNextPage = UserDefaults.standard.object(forKey: "autoNextPage") as? Bool ?? false
         let savedDelay = UserDefaults.standard.integer(forKey: "autoNextPageDelay")
-        self.autoNextPageDelay = savedDelay > 0 ? savedDelay : 3
+        self.autoNextPageDelay = [0, 1, 3, 5].contains(savedDelay)
+            && UserDefaults.standard.object(forKey: "autoNextPageDelay") != nil
+            ? savedDelay
+            : 3
         let savedFullscreenScreenID = UserDefaults.standard.integer(forKey: "fullscreenScreenID")
         self.fullscreenScreenID = UInt32(savedFullscreenScreenID)
         self.browserServerEnabled = UserDefaults.standard.object(forKey: "browserServerEnabled") as? Bool ?? false

--- a/Textream/Textream/SettingsView.swift
+++ b/Textream/Textream/SettingsView.swift
@@ -1106,16 +1106,17 @@ struct SettingsView: View {
                 .toggleStyle(.checkbox)
 
                 if settings.autoNextPage {
-                    HStack {
+                    VStack(alignment: .leading, spacing: 8) {
                         Text("Countdown")
                             .font(.system(size: 13))
-                        Spacer()
-                        Picker("", selection: $settings.autoNextPageDelay) {
+                        Picker("Countdown", selection: $settings.autoNextPageDelay) {
+                            Text("Instant").tag(0)
+                            Text("1 second").tag(1)
                             Text("3 seconds").tag(3)
                             Text("5 seconds").tag(5)
                         }
                         .pickerStyle(.segmented)
-                        .frame(width: 160)
+                        .labelsHidden()
                     }
                 }
             }

--- a/Textream/Textream/TextreamService.swift
+++ b/Textream/Textream/TextreamService.swift
@@ -141,14 +141,16 @@ class TextreamService: NSObject, ObservableObject {
     }
 
     func updatePageInfo() {
-        let content = overlayController.overlayContent
-        content.pageCount = pages.count
-        content.currentPageIndex = currentPageIndex
-        content.pagePreviews = pages.enumerated().map { (i, text) in
+        let pagePreviews = pages.enumerated().map { (i, text) in
             let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
             if trimmed.isEmpty { return "" }
             let preview = String(trimmed.prefix(40))
             return preview + (trimmed.count > 40 ? "…" : "")
+        }
+        for content in [overlayController.overlayContent, externalDisplayController.overlayContent] {
+            content.pageCount = pages.count
+            content.currentPageIndex = currentPageIndex
+            content.pagePreviews = pagePreviews
         }
     }
 


### PR DESCRIPTION
Closes #114.

## Summary

Adds two shorter Auto Next Page timings for scripts with frequent page boundaries:

- Instant
- 1 second
- 3 seconds
- 5 seconds

The segmented control now sits below its label so all four choices fit at the existing Settings window width.

## Implementation

- A zero-second delay advances asynchronously on the next main-loop turn and does not start a timer.
- Notch, floating, and fullscreen teleprompter modes all honor the selected timing.
- The primary fullscreen view owns its countdown; secondary external/mirrored views do not start duplicate timers.
- Each page gets a distinct `SpeechScrollView` identity so in-place page changes cannot retain stale word geometry or scroll position.
- Timer and manual-scroll state reset on page index changes rather than relying only on a changed character count.
- Page metadata is propagated to companion external displays so they reset on the same transition.
- Preference loading distinguishes a saved zero from a missing key, allowing Instant to survive relaunch.
- Missing or unsupported stored values still fall back to the existing 3-second default.
- Reset All remains unchanged at 3 seconds.

## Verification

- Type-checked all macOS Swift sources using the command-line macOS SDK. (`#Preview` was removed only from a temporary staging copy because Command Line Tools does not include the preview macro plugin.)
- Built and ad-hoc signed a local integration app.
- Verified the final Settings layout visually at the existing window size with no clipped labels.
- Selected Instant, relaunched Textream Local, and confirmed Instant remained selected.
- Selected 1 second and confirmed the persisted delay changed to `1`.
- Ran a two-page Classic-mode fixture through the dedicated fullscreen teleprompter with Instant selected. It advanced automatically from page one to page two without clicking Next Page.
- Confirmed page two continued scrolling from its opening lines through its midpoint and final line; the pre-fix build remained stuck at the page-two opening lines under the same test.
- Restored Word Tracking, reopened the original multi-page document, and left the local setting on Instant.
